### PR TITLE
Move as.{factor,ordered}.integer64 to integer64.R (collation order issue)

### DIFF
--- a/R/highlevel64.R
+++ b/R/highlevel64.R
@@ -2479,59 +2479,6 @@ table.integer64 <- function(
   cnt
 }
 
-
-as.factor.integer64 <- function(x){
-
-    cache_env <- cache(x)
-    if (is.null(cache_env$order)){
-        s <- clone(x)
-        o <- seq_along(s)
-        na.count <- ramsortorder(s,o)
-        nu <- sortnut(s)[["nunique"]]
-    }else if (is.null(cache_env$sort)){
-        o <- cache_env$order
-        s <- x[o]
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }else{
-        o <- cache_env$order
-        s <- cache_env$sort
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }
-    dimtab <- sortuni(s, nu)
-    dimpos <- sortorderkey(s,o,na.skip.num=na.count) - 1L
-    attr(dimpos, "levels") <- dimtab
-    oldClass(dimpos) <- "factor"
-    dimpos
-}
-
-as.ordered.integer64 <- function(x){
-
-    cache_env <- cache(x)
-    if (is.null(cache_env$order)){
-        s <- clone(x)
-        o <- seq_along(s)
-        na.count <- ramsortorder(s,o)
-        nu <- sortnut(s)[["nunique"]]
-    }else if (is.null(cache_env$sort)){
-        o <- cache_env$order
-        s <- x[o]
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }else{
-        o <- cache_env$order
-        s <- cache_env$sort
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }
-    dimtab <- sortuni(s, nu)
-    dimpos <- sortorderkey(s,o,na.skip.num=na.count) - 1L
-    attr(dimpos, "levels") <- dimtab
-    oldClass(dimpos) <- c("ordered", "factor")
-    dimpos
-}
-
 as.integer64.factor <- function(x, ...)as.integer64(unclass(x))
 
 

--- a/R/integer64.R
+++ b/R/integer64.R
@@ -2069,6 +2069,58 @@ print.bitstring <- function(x, ...){
   NextMethod(x)
 }
 
+as.factor.integer64 <- function(x){
+
+    cache_env <- cache(x)
+    if (is.null(cache_env$order)){
+        s <- clone(x)
+        o <- seq_along(s)
+        na.count <- ramsortorder(s,o)
+        nu <- sortnut(s)[["nunique"]]
+    }else if (is.null(cache_env$sort)){
+        o <- cache_env$order
+        s <- x[o]
+        na.count <- cache_env$na.count
+        nu <- cache_env$nunique
+    }else{
+        o <- cache_env$order
+        s <- cache_env$sort
+        na.count <- cache_env$na.count
+        nu <- cache_env$nunique
+    }
+    dimtab <- sortuni(s, nu)
+    dimpos <- sortorderkey(s,o,na.skip.num=na.count) - 1L
+    attr(dimpos, "levels") <- dimtab
+    oldClass(dimpos) <- "factor"
+    dimpos
+}
+
+as.ordered.integer64 <- function(x){
+
+    cache_env <- cache(x)
+    if (is.null(cache_env$order)){
+        s <- clone(x)
+        o <- seq_along(s)
+        na.count <- ramsortorder(s,o)
+        nu <- sortnut(s)[["nunique"]]
+    }else if (is.null(cache_env$sort)){
+        o <- cache_env$order
+        s <- x[o]
+        na.count <- cache_env$na.count
+        nu <- cache_env$nunique
+    }else{
+        o <- cache_env$order
+        s <- cache_env$sort
+        na.count <- cache_env$na.count
+        nu <- cache_env$nunique
+    }
+    dimtab <- sortuni(s, nu)
+    dimpos <- sortorderkey(s,o,na.skip.num=na.count) - 1L
+    attr(dimpos, "levels") <- dimtab
+    oldClass(dimpos) <- c("ordered", "factor")
+    dimpos
+}
+
 as.integer64.bitstring <- function(x, ...){
   ret <- .Call(C_as_integer64_bitstring, x, double(length(x)))
   oldClass(ret) <- "integer64"


### PR DESCRIPTION
Given https://github.com/r-lib/roxygen2/issues/1665

Split off from #61 to keep the commit history a tiny bit cleaner. Already confirmed in #61 that this has the intended effect.