### PR TITLE
Remove unused, unexported as.{factor,ordered}.integer64

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -72,7 +72,7 @@
 #!  \code{\link[bit]{still.identical}} for testing whether to symbols point to the same RAM. \cr
 #!     Functions that get and set small cache-content automatically when a cache is present: \code{\link[bit:Metadata]{na.count}}, \code{\link[bit:Metadata]{nvalid}}, \code{\link[bit:Metadata]{is.sorted}}, \code{\link[bit:Metadata]{nunique}} and \code{\link[bit:Metadata]{nties}} \cr
 #!     Setting big caches with a relevant memory footprint requires a conscious decision of the user: \code{\link{hashcache}}, \code{\link{sortcache}}, \code{\link{ordercache}} and \code{\link{sortordercache}} \cr
-#!     Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{as.factor.integer64}}, \code{\link{as.ordered.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
+#!     Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
 #! }
 #! \examples{
 #!     x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))

--- a/R/highlevel64.R
+++ b/R/highlevel64.R
@@ -2210,11 +2210,6 @@ unipos.integer64 <- function(x
 #! \note{
 #!   Note that by using \code{\link{as.integer64.factor}} we can also input
 #!   factors into \code{table.integer64} -- only the \code{\link{levels}} get lost.
-#!  \cr
-#!   Note that because of the existence of \code{\link{as.factor.integer64}}
-#! the standard \code{\link{table}} function -- within its limits -- can also be used
-#! for \code{\link{integer64}}, and especially for combining \code{\link{integer64}} input
-#! with other data types.
 #! }
 #! \seealso{
 #!   \code{\link{table}} for more info on the standard version coping with Base R's data types, \code{\link{tabulate}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, \code{\link{unique.integer64}} for the unique values without counting them and \code{\link{unipos.integer64}} for the positions of the unique values.
@@ -2232,11 +2227,6 @@ unipos.integer64 <- function(x
 #! message("via as.integer64.factor we can use 'table.integer64' also for factors")
 #! table.integer64(x, as.integer64(as.factor(z)))
 #!
-#! message("via as.factor.integer64 we can also use 'table' for integer64")
-#! table(x)
-#! table(x, exclude=NULL)
-#! table(x, z, exclude=NULL)
-#!
 #! \dontshow{
 #!  stopifnot(identical(table.integer64(as.integer64(c(1,1,2))), table(c(1,1,2))))
 #!  stopifnot(identical(table.integer64(as.integer64(c(1,1,2)),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
@@ -2244,7 +2234,7 @@ unipos.integer64 <- function(x
 #!  stopifnot(identical(table.integer64(c(1,1,2)), table(c(1,1,2))))
 #!  stopifnot(identical(table.integer64(as.integer64(c(1,1,2)),c(3,4,4)), table(c(1,1,2),c(3,4,4))))
 #!  stopifnot(identical(table.integer64(c(1,1,2),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
-#!  message("the following works because of as.factor.integer64")
+#!  message("the following works because of ?")
 #!  stopifnot(identical(table(as.integer64(c(1,1,2))), table(c(1,1,2))))
 #!  stopifnot(identical(table(as.integer64(c(1,1,2)),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
 #!  stopifnot(identical(table(as.integer64(c(1,1,2)),c(3,4,4)), table(c(1,1,2),c(3,4,4))))

--- a/R/integer64.R
+++ b/R/integer64.R
@@ -294,8 +294,6 @@
 #!    \code{\link{unipos.integer64}} \tab \code{\link{unipos}} \tab positions corresponding to unique values (h/s/o/so) \cr
 #!    \code{\link{tiepos.integer64}} \tab \code{\link{tiepos}} \tab positions of values that are tied (//o/so) \cr
 #!    \code{\link{keypos.integer64}} \tab \code{\link{keypos}} \tab position of current value in sorted list of unique values (//o/so) \cr
-#!    \code{\link{as.factor.integer64}} \tab \code{\link{as.factor}} \tab convert to (unordered) factor with sorted levels of previous values (//o/so) \cr
-#!    \code{\link{as.ordered.integer64}} \tab \code{\link{as.ordered}} \tab convert to ordered factor with sorted levels of previous values (//o/so) \cr
 #!    \code{\link{table.integer64}} \tab \code{\link{table}} \tab unique values and their frequencies (h/s/o/so) \cr
 #!    \code{\link{sort.integer64}} \tab \code{\link{sort}} \tab sorted vector (/s/o/so) \cr
 #!    \code{\link{order.integer64}} \tab \code{\link{order}} \tab positions of elements that would create sorted vector (//o/so) \cr
@@ -954,8 +952,6 @@
 #! \alias{as.bitstring}
 #! \alias{print.bitstring}
 #! \alias{as.bitstring.integer64}
-#! \alias{as.factor.integer64}
-#! \alias{as.ordered.integer64}
 #! \alias{as.list.integer64}
 #! \title{
 #!    Coerce from integer64
@@ -2067,58 +2063,6 @@ as.bitstring.integer64 <- function(x, ...){
 print.bitstring <- function(x, ...){
   oldClass(x) <- minusclass(class(x), 'bitstring')
   NextMethod(x)
-}
-
-as.factor.integer64 <- function(x){
-
-    cache_env <- cache(x)
-    if (is.null(cache_env$order)){
-        s <- clone(x)
-        o <- seq_along(s)
-        na.count <- ramsortorder(s,o)
-        nu <- sortnut(s)[["nunique"]]
-    }else if (is.null(cache_env$sort)){
-        o <- cache_env$order
-        s <- x[o]
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }else{
-        o <- cache_env$order
-        s <- cache_env$sort
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }
-    dimtab <- sortuni(s, nu)
-    dimpos <- sortorderkey(s,o,na.skip.num=na.count) - 1L
-    attr(dimpos, "levels") <- dimtab
-    oldClass(dimpos) <- "factor"
-    dimpos
-}
-
-as.ordered.integer64 <- function(x){
-
-    cache_env <- cache(x)
-    if (is.null(cache_env$order)){
-        s <- clone(x)
-        o <- seq_along(s)
-        na.count <- ramsortorder(s,o)
-        nu <- sortnut(s)[["nunique"]]
-    }else if (is.null(cache_env$sort)){
-        o <- cache_env$order
-        s <- x[o]
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }else{
-        o <- cache_env$order
-        s <- cache_env$sort
-        na.count <- cache_env$na.count
-        nu <- cache_env$nunique
-    }
-    dimtab <- sortuni(s, nu)
-    dimpos <- sortorderkey(s,o,na.skip.num=na.count) - 1L
-    attr(dimpos, "levels") <- dimtab
-    oldClass(dimpos) <- c("ordered", "factor")
-    dimpos
 }
 
 as.integer64.bitstring <- function(x, ...){

--- a/R/sortuse64.R
+++ b/R/sortuse64.R
@@ -123,7 +123,7 @@
 #!   \item{nomatch}{ the value to be returned if an element is not found in the hashmap }
 #!   \item{keep.order}{ determines order of results and speed: \code{FALSE} (the default) is faster and returns in sorted order, \code{TRUE} returns in the order of first appearance in the original data, but this requires extra work }
 #!   \item{probs}{ vector of probabilities in [0..1] for which we seek quantiles }
-#!   \item{na.skip.num}{ 0 or the number of \code{NA}s. With 0, \code{NA}s are coded with 1L, with the number of \code{NA}s, these are coded with \code{NA}, the latter needed for \code{\link{as.factor.integer64}} }
+#!   \item{na.skip.num}{ 0 or the number of \code{NA}s. With 0, \code{NA}s are coded with 1L, with the number of \code{NA}s, these are coded with \code{NA} }
 #!   \item{na.count}{ the number of \code{NA}s, needed for this low-level function algorithm }
 #!   \item{method}{ see details }
 #!   \item{\dots}{ further arguments, passed from generics, ignored in methods }

--- a/man/as.character.integer64.Rd
+++ b/man/as.character.integer64.Rd
@@ -6,8 +6,6 @@
 \alias{as.bitstring}
 \alias{print.bitstring}
 \alias{as.bitstring.integer64}
-\alias{as.factor.integer64}
-\alias{as.ordered.integer64}
 \alias{as.list.integer64}
 \title{
    Coerce from integer64
@@ -26,8 +24,6 @@
  \method{as.double}{integer64}(x, keep.names = FALSE, \dots)
  \method{as.integer}{integer64}(x, \dots)
  \method{as.logical}{integer64}(x, \dots)
- \method{as.factor}{integer64}(x)
- \method{as.ordered}{integer64}(x)
  \method{as.list}{integer64}(x, \dots)
 }
 \arguments{

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -284,8 +284,6 @@ is not worth it with 32x at duplicated RAM consumption).
    \code{\link{unipos.integer64}} \tab \code{\link{unipos}} \tab positions corresponding to unique values (h/s/o/so) \cr
    \code{\link{tiepos.integer64}} \tab \code{\link{tiepos}} \tab positions of values that are tied (//o/so) \cr
    \code{\link{keypos.integer64}} \tab \code{\link{keypos}} \tab position of current value in sorted list of unique values (//o/so) \cr
-   \code{\link{as.factor.integer64}} \tab \code{\link{as.factor}} \tab convert to (unordered) factor with sorted levels of previous values (//o/so) \cr
-   \code{\link{as.ordered.integer64}} \tab \code{\link{as.ordered}} \tab convert to ordered factor with sorted levels of previous values (//o/so) \cr
    \code{\link{table.integer64}} \tab \code{\link{table}} \tab unique values and their frequencies (h/s/o/so) \cr
    \code{\link{sort.integer64}} \tab \code{\link{sort}} \tab sorted vector (/s/o/so) \cr
    \code{\link{order.integer64}} \tab \code{\link{order}} \tab positions of elements that would create sorted vector (//o/so) \cr

--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -62,7 +62,7 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
  \code{\link[bit]{still.identical}} for testing whether to symbols point to the same RAM. \cr
     Functions that get and set small cache-content automatically when a cache is present: \code{\link[bit:Metadata]{na.count}}, \code{\link[bit:Metadata]{nvalid}}, \code{\link[bit:Metadata]{is.sorted}}, \code{\link[bit:Metadata]{nunique}} and \code{\link[bit:Metadata]{nties}} \cr
     Setting big caches with a relevant memory footprint requires a conscious decision of the user: \code{\link{hashcache}}, \code{\link{sortcache}}, \code{\link{ordercache}} and \code{\link{sortordercache}} \cr
-    Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{as.factor.integer64}}, \code{\link{as.ordered.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
+    Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
 }
 \examples{
     x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))

--- a/man/sortnut.Rd
+++ b/man/sortnut.Rd
@@ -113,7 +113,7 @@ sortorderrnk(sorted, order, na.count, \dots)
   \item{nomatch}{ the value to be returned if an element is not found in the hashmap }
   \item{keep.order}{ determines order of results and speed: \code{FALSE} (the default) is faster and returns in sorted order, \code{TRUE} returns in the order of first appearance in the original data, but this requires extra work }
   \item{probs}{ vector of probabilities in [0..1] for which we seek quantiles }
-  \item{na.skip.num}{ 0 or the number of \code{NA}s. With 0, \code{NA}s are coded with 1L, with the number of \code{NA}s, these are coded with \code{NA}, the latter needed for \code{\link{as.factor.integer64}} }
+  \item{na.skip.num}{ 0 or the number of \code{NA}s. With 0, \code{NA}s are coded with 1L, with the number of \code{NA}s, these are coded with \code{NA} }
   \item{na.count}{ the number of \code{NA}s, needed for this low-level function algorithm }
   \item{method}{ see details }
   \item{\dots}{ further arguments, passed from generics, ignored in methods }

--- a/man/table.integer64.Rd
+++ b/man/table.integer64.Rd
@@ -75,11 +75,6 @@ and \code{\link{ordertab}} (memory saving ordering).
 \note{
   Note that by using \code{\link{as.integer64.factor}} we can also input
   factors into \code{table.integer64} -- only the \code{\link{levels}} get lost.
- \cr
-  Note that because of the existence of \code{\link{as.factor.integer64}}
-the standard \code{\link{table}} function -- within its limits -- can also be used
-for \code{\link{integer64}}, and especially for combining \code{\link{integer64}} input
-with other data types.
 }
 \seealso{
   \code{\link{table}} for more info on the standard version coping with Base R's data types, \code{\link{tabulate}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, \code{\link{unique.integer64}} for the unique values without counting them and \code{\link{unipos.integer64}} for the positions of the unique values.
@@ -97,11 +92,6 @@ table.integer64(x, y, return="data.frame")
 message("via as.integer64.factor we can use 'table.integer64' also for factors")
 table.integer64(x, as.integer64(as.factor(z)))
 
-message("via as.factor.integer64 we can also use 'table' for integer64")
-table(x)
-table(x, exclude=NULL)
-table(x, z, exclude=NULL)
-
 \dontshow{
  stopifnot(identical(table.integer64(as.integer64(c(1,1,2))), table(c(1,1,2))))
  stopifnot(identical(table.integer64(as.integer64(c(1,1,2)),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
@@ -109,7 +99,7 @@ table(x, z, exclude=NULL)
  stopifnot(identical(table.integer64(c(1,1,2)), table(c(1,1,2))))
  stopifnot(identical(table.integer64(as.integer64(c(1,1,2)),c(3,4,4)), table(c(1,1,2),c(3,4,4))))
  stopifnot(identical(table.integer64(c(1,1,2),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
- message("the following works because of as.factor.integer64")
+ message("the following works because of ?")
  stopifnot(identical(table(as.integer64(c(1,1,2))), table(c(1,1,2))))
  stopifnot(identical(table(as.integer64(c(1,1,2)),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
  stopifnot(identical(table(as.integer64(c(1,1,2)),c(3,4,4)), table(c(1,1,2),c(3,4,4))))


### PR DESCRIPTION
More fallout from #61.

Raised to attention because in the manually generated .Rd, these are documented like S3 methods:

https://github.com/r-lib/bit64/blob/c35cb5d7d3f34a9d767d17f6ff4215b9cd169fee/man/as.character.integer64.Rd#L29-L30

But the {roxygen2} output is:

```
as.factor.integer64(x)
as.ordered.integer64(x)
```

AFAICT these functions are totally unused, and don't even work:

```r
as.factor.integer64(as.integer64(2:10))
# Error in as.character.factor(x) : malformed factor
```

There's no reference to them on CRAN:

https://github.com/search?q=org%3Acran+%2Fas%5C.%28factor%7Cordered%29%5C.integer64%2F&type=code

Nor elsewhere on GitHub AFAICT

https://github.com/search?q=lang%3AR+%2Fas%5C.%28factor%7Cordered%29%5C.integer64%2F+-path%3A64&type=code

So I am going ahead with merging this without further fuss.