### PR TITLE
match canonical ordering of roxygen

### DIFF
--- a/man/all.equal.integer64.Rd
+++ b/man/all.equal.integer64.Rd
@@ -3,9 +3,6 @@
 \title{
    Test if two integer64 vectors are all.equal
 }
-\description{
-   A utility to compare integer64 objects 'x' and 'y' testing for ‘near equality’, see \code{\link{all.equal}}.
-}
 \usage{
   \method{all.equal}{integer64}(
   target
@@ -44,6 +41,9 @@
   Either ‘TRUE’ (‘NULL’ for ‘attr.all.equal’) or a vector of ‘mode’
   ‘"character"’ describing the differences between ‘target’ and
   ‘current’.
+}
+\description{
+   A utility to compare integer64 objects 'x' and 'y' testing for ‘near equality’, see \code{\link{all.equal}}.
 }
 \details{
    In \code{\link{all.equal.numeric}} the type \code{integer} is treated as a proper subset of \code{double}

--- a/man/all.equal.integer64.Rd
+++ b/man/all.equal.integer64.Rd
@@ -61,12 +61,12 @@
 \author{
   Leonardo Silvestri (for package nanotime)
 }
-\seealso{
-  \code{\link{all.equal}}
-}
 \examples{
   all.equal(as.integer64(1:10), as.integer64(0:9))
   all.equal(as.integer64(1:10), as.integer(1:10))
   all.equal(as.integer64(1:10), as.double(1:10))
   all.equal(as.integer64(1), as.double(1e300))
+}
+\seealso{
+  \code{\link{all.equal}}
 }

--- a/man/as.character.integer64.Rd
+++ b/man/as.character.integer64.Rd
@@ -10,12 +10,6 @@
 \title{
    Coerce from integer64
 }
-\description{
-  Methods to coerce integer64 to other atomic types.
-  'as.bitstring' coerces to a human-readable bit representation (strings of zeroes and ones).
-  The methods \code{\link{format}}, \code{\link{as.character}}, \code{\link{as.double}},
-  \code{\link{as.logical}}, \code{\link{as.integer}} do what you would expect.
-}
 \usage{
  as.bitstring(x, ...)
 
@@ -41,6 +35,12 @@
 \value{
   \code{as.bitstring} returns a string of class 'bitstring'. \cr
   The other methods return atomic vectors of the expected types
+}
+\description{
+  Methods to coerce integer64 to other atomic types.
+  'as.bitstring' coerces to a human-readable bit representation (strings of zeroes and ones).
+  The methods \code{\link{format}}, \code{\link{as.character}}, \code{\link{as.double}},
+  \code{\link{as.logical}}, \code{\link{as.integer}} do what you would expect.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/as.character.integer64.Rd
+++ b/man/as.character.integer64.Rd
@@ -47,7 +47,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
 \keyword{ classes }
 \keyword{ manip }
-\seealso{ \code{\link{as.integer64.character}} \code{\link{integer64}}  }
 \examples{
   as.character(lim.integer64())
   as.bitstring(lim.integer64())
@@ -55,3 +54,4 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
    -2,-1,NA,0:2
   )))
 }
+\seealso{ \code{\link{as.integer64.character}} \code{\link{integer64}}  }

--- a/man/as.character.integer64.Rd
+++ b/man/as.character.integer64.Rd
@@ -45,8 +45,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
 \examples{
   as.character(lim.integer64())
   as.bitstring(lim.integer64())
@@ -55,3 +53,5 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   )))
 }
 \seealso{ \code{\link{as.integer64.character}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/as.data.frame.integer64.Rd
+++ b/man/as.data.frame.integer64.Rd
@@ -28,10 +28,10 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
 \keyword{ classes }
 \keyword{ manip }
-\seealso{
-  \code{\link{cbind.integer64}} \code{\link{integer64}}  %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}}
-}
 \examples{
   as.data.frame.integer64(as.integer64(1:12))
   data.frame(a=1:12, b=as.integer64(1:12))
+}
+\seealso{
+  \code{\link{cbind.integer64}} \code{\link{integer64}}  %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}}
 }

--- a/man/as.data.frame.integer64.Rd
+++ b/man/as.data.frame.integer64.Rd
@@ -3,9 +3,6 @@
 \title{
    integer64: Coercing to data.frame column
 }
-\description{
-  Coercing integer64 vector to data.frame.
-}
 \usage{
   \method{as.data.frame}{integer64}(x, ...)
 }
@@ -15,6 +12,9 @@
 }
 \value{
   a one-column data.frame containing an integer64 vector
+}
+\description{
+  Coercing integer64 vector to data.frame.
 }
 \details{
   'as.data.frame.integer64' is rather not intended to be called directly,

--- a/man/as.data.frame.integer64.Rd
+++ b/man/as.data.frame.integer64.Rd
@@ -26,8 +26,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
 \examples{
   as.data.frame.integer64(as.integer64(1:12))
   data.frame(a=1:12, b=as.integer64(1:12))
@@ -35,3 +33,5 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 \seealso{
   \code{\link{cbind.integer64}} \code{\link{integer64}}  %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}}
 }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/as.integer64.character.Rd
+++ b/man/as.integer64.character.Rd
@@ -56,8 +56,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
 \examples{
 as.integer64(as.character(lim.integer64()))
 as.integer64(
@@ -80,3 +78,5 @@ as.integer64(
 )
 }
 \seealso{ \code{\link{as.character.integer64}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/as.integer64.character.Rd
+++ b/man/as.integer64.character.Rd
@@ -58,7 +58,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
 \keyword{ classes }
 \keyword{ manip }
-\seealso{ \code{\link{as.character.integer64}} \code{\link{integer64}}  }
 \examples{
 as.integer64(as.character(lim.integer64()))
 as.integer64(
@@ -80,3 +79,4 @@ as.integer64(
   ), class = "bitstring")
 )
 }
+\seealso{ \code{\link{as.character.integer64}} \code{\link{integer64}}  }

--- a/man/as.integer64.character.Rd
+++ b/man/as.integer64.character.Rd
@@ -12,9 +12,6 @@
 \title{
    Coerce to integer64
 }
-\description{
-  Methods to coerce from other atomic types to integer64.
-}
 \usage{
  NA_integer64_
 
@@ -41,6 +38,12 @@
   \item{keep.names}{ FALSE, set to TRUE to keep a names vector }
   \item{...}{ further arguments to the \code{\link{NextMethod}} }
 }
+\value{
+  The other methods return atomic vectors of the expected types
+}
+\description{
+  Methods to coerce from other atomic types to integer64.
+}
 \details{
   \code{as.integer64.character} is realized using C function \code{strtoll} which does not support scientific notation.
   Instead of '1e6' use '1000000'.
@@ -49,9 +52,6 @@
   multi-byte characters are not allowed,
   strings shorter than 64 characters are treated as if they were left-padded with '0',
   strings longer than 64 bytes are mapped to \code{NA_INTEGER64} and a warning is emitted.
-}
-\value{
-  The other methods return atomic vectors of the expected types
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/benchmark64.Rd
+++ b/man/benchmark64.Rd
@@ -5,10 +5,6 @@
  Function for measuring algorithmic performance \cr
  of high-level and low-level integer64 functions
 }
-\description{
- \code{benchmark64} compares high-level integer64 functions against the integer functions from Base R \cr
- \code{optimizer64} compares for each high-level integer64 function the Base R integer function with several low-level integer64 functions with and without caching \cr
-}
 \usage{
 benchmark64(nsmall = 2^16, nbig = 2^25, timefun = repeat.time
 )
@@ -36,6 +32,15 @@ optimizer64(nsmall = 2^16, nbig = 2^25, timefun = repeat.time
   \item{plot}{
  set to FALSE to suppress plotting
 }
+}
+\value{
+ \code{benchmark64} returns a matrix with elapsed seconds, different high-level tasks in rows and different scenarios to solve the task in columns. The last row named 'SESSION' contains the elapsed seconds of the exemplary sesssion.
+ \cr
+ \code{optimizer64} returns a dimensioned list with one row for each high-level function timed and two columns named after the values of the \code{nsmall} and \code{nbig} sample sizes. Each list cell contains a matrix with timings, low-level-methods in rows and three measurements \code{c("prep","both","use")} in columns. If it can be measured separately, \code{prep} contains the timing of preparatory work such as sorting and hashing, and \code{use} contains the timing of using the prepared work. If the function timed does both, preparation and use, the timing is in \code{both}.
+}
+\description{
+ \code{benchmark64} compares high-level integer64 functions against the integer functions from Base R \cr
+ \code{optimizer64} compares for each high-level integer64 function the Base R integer function with several low-level integer64 functions with and without caching \cr
 }
 \details{
  \code{benchmark64} compares the following scenarios for the following use cases:
@@ -68,11 +73,6 @@ optimizer64(nsmall = 2^16, nbig = 2^25, timefun = repeat.time
   SESSION       \tab exemplary session involving multiple calls (including cache filling costs) \cr
  }
  Note that the timings for the cached variants do \emph{not} contain the time costs of building the cache, except for the timing of the exemplary user session, where the cache costs are included in order to evaluate amortization.
-}
-\value{
- \code{benchmark64} returns a matrix with elapsed seconds, different high-level tasks in rows and different scenarios to solve the task in columns. The last row named 'SESSION' contains the elapsed seconds of the exemplary sesssion.
- \cr
- \code{optimizer64} returns a dimensioned list with one row for each high-level function timed and two columns named after the values of the \code{nsmall} and \code{nbig} sample sizes. Each list cell contains a matrix with timings, low-level-methods in rows and three measurements \code{c("prep","both","use")} in columns. If it can be measured separately, \code{prep} contains the timing of preparatory work such as sorting and hashing, and \code{use} contains the timing of using the prepared work. If the function timed does both, preparation and use, the timing is in \code{both}.
 }
 \author{
  Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/benchmark64.Rd
+++ b/man/benchmark64.Rd
@@ -77,9 +77,6 @@ optimizer64(nsmall = 2^16, nbig = 2^25, timefun = repeat.time
 \author{
  Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
- \code{\link{integer64}}
-}
 \examples{
 message("this small example using system.time does not give serious timings\n
 this we do this only to run regression tests")
@@ -130,5 +127,8 @@ for (i in 1:nrow(optimizer64.data)){
  }
 }
 par(mfrow=c(1,1))
+}
+\seealso{
+ \code{\link{integer64}}
 }
 \keyword{ misc }

--- a/man/benchmark64.data.Rd
+++ b/man/benchmark64.data.Rd
@@ -4,7 +4,6 @@
 \title{
  Results of performance measurement on a Core i7 Lenovo T410 8 GB RAM under Windows 7 64bit
 }
-\usage{data(benchmark64.data)}
 \format{
   The format is:
  num [1:16, 1:6] 2.55e-05 2.37 2.39 1.28 1.39 ...
@@ -12,6 +11,7 @@
   ..$ : chr [1:16] "cache" "match(s,b)" "s \%in\% b" "match(b,s)" ...
   ..$ : chr [1:6] "32-bit" "64-bit" "hashcache" "sortordercache" ...
 }
+\usage{data(benchmark64.data)}
 \description{
   These are the results of calling \code{\link{benchmark64}}
 }

--- a/man/benchmark64.data.Rd
+++ b/man/benchmark64.data.Rd
@@ -4,9 +4,6 @@
 \title{
  Results of performance measurement on a Core i7 Lenovo T410 8 GB RAM under Windows 7 64bit
 }
-\description{
-  These are the results of calling \code{\link{benchmark64}}
-}
 \usage{data(benchmark64.data)}
 \format{
   The format is:
@@ -14,6 +11,9 @@
  - attr(*, "dimnames")=List of 2
   ..$ : chr [1:16] "cache" "match(s,b)" "s \%in\% b" "match(b,s)" ...
   ..$ : chr [1:6] "32-bit" "64-bit" "hashcache" "sortordercache" ...
+}
+\description{
+  These are the results of calling \code{\link{benchmark64}}
 }
 \examples{
 data(benchmark64.data)

--- a/man/benchmark64.data.Rd
+++ b/man/benchmark64.data.Rd
@@ -1,6 +1,6 @@
+\docType{data}
 \name{benchmark64.data}
 \alias{benchmark64.data}
-\docType{data}
 \title{
  Results of performance measurement on a Core i7 Lenovo T410 8 GB RAM under Windows 7 64bit
 }

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -87,6 +87,24 @@ is not worth it with 32x at duplicated RAM consumption).
    Encoding: \tab latin1\cr
 }
 }
+\note{
+   \code{integer64} are useful for handling database keys and exact counting in +-2^63.
+   Do not use them as replacement for 32bit integers, integer64 are not
+   supported for subscripting by R-core and they have different semantics
+   when combined with double. Do understand that \code{integer64} can only be
+   useful over \code{double} if we do not coerce it to \code{double}. \cr
+  \cr
+  While \cr
+  integer + double -> double + double -> double \cr
+  or \cr
+  1L + 0.5 -> 1.5 \cr
+  for additive operations we coerce to \code{integer64} \cr
+  integer64 + double ->  integer64 + integer64 -> integer64 \cr
+  hence \cr
+  as.integer64(1) + 0.5 -> 1LL + 0LL -> 1LL \cr
+  \cr
+  see section "Arithmetic precision and coercion" above
+}
 \section{Design considerations}{
   64 bit integers are related to big data: we need them to overcome address space limitations.
   Therefore performance of the 64 bit integer type is critical.
@@ -403,24 +421,6 @@ is not worth it with 32x at duplicated RAM consumption).
     Such subscripting currently returns \code{9218868437227407266} instead of \code{NA} (the \code{NA} value of the underlying double code).
     Following the full R behaviour here would either destroy performance or require extensive C-coding.
   }
-}
-\note{
-   \code{integer64} are useful for handling database keys and exact counting in +-2^63.
-   Do not use them as replacement for 32bit integers, integer64 are not
-   supported for subscripting by R-core and they have different semantics
-   when combined with double. Do understand that \code{integer64} can only be
-   useful over \code{double} if we do not coerce it to \code{double}. \cr
-  \cr
-  While \cr
-  integer + double -> double + double -> double \cr
-  or \cr
-  1L + 0.5 -> 1.5 \cr
-  for additive operations we coerce to \code{integer64} \cr
-  integer64 + double ->  integer64 + integer64 -> integer64 \cr
-  hence \cr
-  as.integer64(1) + 0.5 -> 1LL + 0LL -> 1LL \cr
-  \cr
-  see section "Arithmetic precision and coercion" above
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -422,13 +422,6 @@ is not worth it with 32x at duplicated RAM consumption).
     Following the full R behaviour here would either destroy performance or require extensive C-coding.
   }
 }
-\author{
-Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
-Maintainer: Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
-}
-\keyword{ package }
-\keyword{ classes }
-\keyword{ manip }
 \examples{
 message("Using integer64 in vector")
 x <- integer64(8)    # create 64 bit vector
@@ -896,3 +889,10 @@ matplot(1:21, cbind(td32, t64), pch=c("d","i"), log="y")
 
 }
 \seealso{ \code{\link{integer}} in base R }
+\author{
+Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
+Maintainer: Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
+}
+\keyword{ package }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -429,7 +429,6 @@ Maintainer: Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 \keyword{ package }
 \keyword{ classes }
 \keyword{ manip }
-\seealso{ \code{\link{integer}} in base R }
 \examples{
 message("Using integer64 in vector")
 x <- integer64(8)    # create 64 bit vector
@@ -896,3 +895,4 @@ matplot(1:21, cbind(td32, t64), pch=c("d","i"), log="y")
   }
 
 }
+\seealso{ \code{\link{integer}} in base R }

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -1,3 +1,4 @@
+\docType{package}
 \name{bit64-package}
 \alias{bit64-package}
 \alias{bit64}
@@ -9,7 +10,6 @@
 \alias{length<-.integer64}
 \alias{print.integer64}
 \alias{str.integer64}
-\docType{package}
 \title{
    A S3 class for vectors of 64bit integers
 }

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -13,6 +13,32 @@
 \title{
    A S3 class for vectors of 64bit integers
 }
+\usage{
+ integer64(length)
+
+ \method{is}{integer64}(x)
+
+ \method{length}{integer64}(x) <- value
+
+ \method{print}{integer64}(x, quote=FALSE, ...)
+
+ \method{str}{integer64}(object, vec.len  = strO$vec.len, give.head = TRUE, give.length = give.head, ...)
+}
+\arguments{
+  \item{length}{ length of vector using \code{\link{integer}} }
+  \item{x}{ an integer64 vector }
+  \item{object}{ an integer64 vector }
+  \item{value}{ an integer64 vector of values to be assigned }
+  \item{quote}{ logical, indicating whether or not strings should be printed with surrounding quotes. }
+  \item{vec.len}{ see \code{\link[utils]{str}} }
+  \item{give.head}{ see \code{\link[utils]{str}} }
+  \item{give.length}{ see \code{\link[utils]{str}} }
+  \item{...}{ further arguments to the \code{\link{NextMethod}} }
+}
+\value{
+  \code{integer64} returns a vector of 'integer64',
+   i.e. a vector of \code{\link{double}} decorated with class 'integer64'.
+}
 \description{
 Package 'bit64' provides fast serializable S3 atomic 64bit (signed) integers
 that can be used in vectors, matrices, arrays and data.frames. Methods are
@@ -49,28 +75,6 @@ session using a couple of these operations the 64-bit integers performed 22x
  faster than base 32-bit integers, hash-caching improved this to 24x,
 sortorder-caching was most efficient with 38x (caching hashing and sorting
 is not worth it with 32x at duplicated RAM consumption).
-}
-\usage{
- integer64(length)
-
- \method{is}{integer64}(x)
-
- \method{length}{integer64}(x) <- value
-
- \method{print}{integer64}(x, quote=FALSE, ...)
-
- \method{str}{integer64}(object, vec.len  = strO$vec.len, give.head = TRUE, give.length = give.head, ...)
-}
-\arguments{
-  \item{length}{ length of vector using \code{\link{integer}} }
-  \item{x}{ an integer64 vector }
-  \item{object}{ an integer64 vector }
-  \item{value}{ an integer64 vector of values to be assigned }
-  \item{quote}{ logical, indicating whether or not strings should be printed with surrounding quotes. }
-  \item{vec.len}{ see \code{\link[utils]{str}} }
-  \item{give.head}{ see \code{\link[utils]{str}} }
-  \item{give.length}{ see \code{\link[utils]{str}} }
-  \item{...}{ further arguments to the \code{\link{NextMethod}} }
 }
 \details{
 \tabular{ll}{
@@ -417,10 +421,6 @@ is not worth it with 32x at duplicated RAM consumption).
   as.integer64(1) + 0.5 -> 1LL + 0LL -> 1LL \cr
   \cr
   see section "Arithmetic precision and coercion" above
-}
-\value{
-  \code{integer64} returns a vector of 'integer64',
-   i.e. a vector of \code{\link{double}} decorated with class 'integer64'.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/bit64S3.Rd
+++ b/man/bit64S3.Rd
@@ -19,9 +19,6 @@
 \title{
   Turning base R functions into S3 generics for bit64
 }
-\description{
-    Turn those base functions S3 generic which are used in bit64
-}
 \usage{
     from:to
 
@@ -64,6 +61,12 @@
   \item{to}{ scalar denoting last element of sequence }
   \item{...}{ ignored }
 }
+\value{
+    \code{\link{invisible}}
+}
+\description{
+    Turn those base functions S3 generic which are used in bit64
+}
 \details{
    The following functions are turned into S3 gernerics in order to dispatch methods for \code{\link{integer64}}:
    \preformatted{
@@ -75,9 +78,6 @@
        \code{\link{rank}}
        \code{\link{order}}
    }
-}
-\value{
-    \code{\link{invisible}}
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/bit64S3.Rd
+++ b/man/bit64S3.Rd
@@ -89,9 +89,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
     \code{\link{\%in\%}} currently only dispatches at its first argument and expects its second argument also to be integer64, otherwise throws an error. Beware of something like \code{2 \%in\% as.integer64(0:3)}
     \code{\link{order}} currently only orders a single argument, trying more than one raises an error
 }
-\seealso{
-    \code{\link{bit64}}, \code{\link{S3}}
-}
 \examples{
  is.double(as.integer64(1))
     as.integer64(1):9
@@ -123,5 +120,8 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
  stopifnot(identical(order(as.integer64(c(1,NA,2))), order(c(1,NA,2))))
  stopifnot(identical(order(as.integer64(c(1,NA,2)), decreasing=TRUE), order(c(1,NA,2), decreasing=TRUE)))
  }
+}
+\seealso{
+    \code{\link{bit64}}, \code{\link{S3}}
 }
 \keyword{ methods }

--- a/man/c.integer64.Rd
+++ b/man/c.integer64.Rd
@@ -29,13 +29,13 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{rep.integer64}} \code{\link{seq.integer64}}
-          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
-}
 \examples{
   c(as.integer64(1), 2:6)
   cbind(1:6, as.integer(1:6))
   rbind(1:6, as.integer(1:6))
 }
+\seealso{ \code{\link{rep.integer64}} \code{\link{seq.integer64}}
+          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
+}
+\keyword{ classes }
+\keyword{ manip }

--- a/man/c.integer64.Rd
+++ b/man/c.integer64.Rd
@@ -5,9 +5,6 @@
 \title{
    Concatenating integer64 vectors
 }
-\description{
-  The ususal functions 'c', 'cbind' and 'rbind'
-}
 \usage{
 \method{c}{integer64}(..., recursive = FALSE)
 
@@ -22,6 +19,9 @@
 \value{
   \code{\link{c}} returns a integer64 vector of the total length of the input \cr
   \code{\link{cbind}} and \code{\link{rbind}} return a integer64 matrix
+}
+\description{
+  The ususal functions 'c', 'cbind' and 'rbind'
 }
 \note{
   R currently only dispatches generic 'c' to method 'c.integer64' if the first argument is 'integer64'

--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -64,12 +64,6 @@ remcache(x)
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
- \code{\link[bit]{still.identical}} for testing whether to symbols point to the same RAM. \cr
-    Functions that get and set small cache-content automatically when a cache is present: \code{\link[bit:Metadata]{na.count}}, \code{\link[bit:Metadata]{nvalid}}, \code{\link[bit:Metadata]{is.sorted}}, \code{\link[bit:Metadata]{nunique}} and \code{\link[bit:Metadata]{nties}} \cr
-    Setting big caches with a relevant memory footprint requires a conscious decision of the user: \code{\link{hashcache}}, \code{\link{sortcache}}, \code{\link{ordercache}} and \code{\link{sortordercache}} \cr
-    Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
-}
 \examples{
     x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
     y <- x
@@ -89,5 +83,11 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
     getcache(x, "abc")
     remcache(x)
     cache(x)
+}
+\seealso{
+ \code{\link[bit]{still.identical}} for testing whether to symbols point to the same RAM. \cr
+    Functions that get and set small cache-content automatically when a cache is present: \code{\link[bit:Metadata]{na.count}}, \code{\link[bit:Metadata]{nvalid}}, \code{\link[bit:Metadata]{is.sorted}}, \code{\link[bit:Metadata]{nunique}} and \code{\link[bit:Metadata]{nties}} \cr
+    Setting big caches with a relevant memory footprint requires a conscious decision of the user: \code{\link{hashcache}}, \code{\link{sortcache}}, \code{\link{ordercache}} and \code{\link{sortordercache}} \cr
+    Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
 }
 \keyword{ environment }

--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -9,9 +9,6 @@
 \title{
     Atomic Caching
 }
-\description{
-    Functions for caching results attached to atomic objects
-}
 \usage{
 newcache(x)
 
@@ -47,6 +44,12 @@ remcache(x)
     ignored
 }
 }
+\value{
+    see details
+}
+\description{
+    Functions for caching results attached to atomic objects
+}
 \details{
     A \code{cache} is an \code{link{environment}} attached to an atomic object with the \code{link{attrib}} name 'cache'.
     It contains at least a reference to the atomic object that carries the cache.
@@ -57,9 +60,6 @@ remcache(x)
     Function \code{setcache(x, which, value)} assigns a value into the cache of \code{x} \cr
     Function \code{getcache(x, which)} gets cache value 'which' from \code{x} \cr
     Function \code{remcache} removes the cache from \code{x} \cr
-}
-\value{
-    see details
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/cumsum.integer64.Rd
+++ b/man/cumsum.integer64.Rd
@@ -7,9 +7,6 @@
 \title{
    Cumulative Sums, Products, Extremes and lagged differences
 }
-\description{
-  Cumulative Sums, Products, Extremes and lagged differences
-}
 \usage{
 \method{cummin}{integer64}(x)
 
@@ -31,6 +28,9 @@
   \code{\link{cummin}}, \code{\link{cummax}} , \code{\link{cumsum}} and \code{\link{cumprod}}
      return a integer64 vector of the same length as their input\cr
   \code{\link{diff}} returns a integer64 vector shorter by \code{lag*differences} elements \cr
+}
+\description{
+  Cumulative Sums, Products, Extremes and lagged differences
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/cumsum.integer64.Rd
+++ b/man/cumsum.integer64.Rd
@@ -35,12 +35,12 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{sum.integer64}} \code{\link{integer64}}  }
 \examples{
   cumsum(rep(as.integer64(1), 12))
   diff(as.integer64(c(0,1:12)))
   cumsum(as.integer64(c(0, 1:12)))
   diff(cumsum(as.integer64(c(0,0,1:12))), differences=2)
 }
+\seealso{ \code{\link{sum.integer64}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/duplicated.integer64.Rd
+++ b/man/duplicated.integer64.Rd
@@ -31,13 +31,13 @@
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{ \code{\link{duplicated}}, \code{\link{unique.integer64}}  }
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 duplicated(x)
 
 stopifnot(identical(duplicated(x),  duplicated(as.integer(x))))
 }
+\seealso{ \code{\link{duplicated}}, \code{\link{unique.integer64}}  }
 \keyword{logic}
 \keyword{manip}
 

--- a/man/duplicated.integer64.Rd
+++ b/man/duplicated.integer64.Rd
@@ -1,11 +1,6 @@
 \name{duplicated.integer64}
 \alias{duplicated.integer64}
 \title{Determine Duplicate Elements of integer64}
-\description{
-  \code{duplicated()} determines which elements of a vector or data frame are duplicates
-  of elements with smaller subscripts, and returns a logical vector
-  indicating which elements (rows) are duplicates.
-}
 \usage{
 \method{duplicated}{integer64}(x, incomparables = FALSE, nunique = NULL, method = NULL, ...)
 }
@@ -20,13 +15,18 @@
 }
   \item{...}{ignored}
 }
+\value{
+    \code{duplicated()}: a logical vector of the same length as \code{x}.
+}
+\description{
+  \code{duplicated()} determines which elements of a vector or data frame are duplicates
+  of elements with smaller subscripts, and returns a logical vector
+  indicating which elements (rows) are duplicates.
+}
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
 
   Suitable methods are \code{\link{hashdup}} (hashing), \code{\link{sortorderdup}} (fast ordering) and \code{\link{orderdup}} (memory saving ordering).
-}
-\value{
-    \code{duplicated()}: a logical vector of the same length as \code{x}.
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/extract.replace.integer64.Rd
+++ b/man/extract.replace.integer64.Rd
@@ -21,15 +21,15 @@
   \item{value}{ an atomic vector with values to be assigned }
   \item{...}{ further arguments to the \code{\link{NextMethod}} }
 }
-\note{
-  You should not subscript non-existing elements and not use \code{NA}s as subscripts.
-  The current implementation returns \code{9218868437227407266} instead of \code{NA}.
-}
 \value{
   A vector or scalar of class 'integer64'
 }
 \description{
   Methods to extract and replace parts of an integer64 vector.
+}
+\note{
+  You should not subscript non-existing elements and not use \code{NA}s as subscripts.
+  The current implementation returns \code{9218868437227407266} instead of \code{NA}.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/extract.replace.integer64.Rd
+++ b/man/extract.replace.integer64.Rd
@@ -6,9 +6,6 @@
 \title{
    Extract or Replace Parts of an integer64 vector
 }
-\description{
-  Methods to extract and replace parts of an integer64 vector.
-}
 \usage{
  \method{[}{integer64}(x, i, ...)
 
@@ -30,6 +27,9 @@
 }
 \value{
   A vector or scalar of class 'integer64'
+}
+\description{
+  Methods to extract and replace parts of an integer64 vector.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/extract.replace.integer64.Rd
+++ b/man/extract.replace.integer64.Rd
@@ -34,9 +34,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{[}} \code{\link{integer64}}  }
 \examples{
   as.integer64(1:12)[1:3]
   x <- as.integer64(1:12)
@@ -49,3 +46,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
     stopifnot(identical(r, as.integer64(as.bitstring(r))))
   }
 }
+\seealso{ \code{\link{[}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/format.integer64.Rd
+++ b/man/format.integer64.Rd
@@ -81,9 +81,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{xor.integer64}} \code{\link{integer64}}  }
 \examples{
   sqrt(as.integer64(1:12))
 \dontshow{
@@ -95,3 +92,6 @@ r <- as.integer64(round(as.integer(i), s))
 }
 }
 }
+\seealso{ \code{\link{xor.integer64}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/format.integer64.Rd
+++ b/man/format.integer64.Rd
@@ -20,9 +20,6 @@
 \title{
    Unary operators and functions for integer64 vectors
 }
-\description{
-  Unary operators and functions for integer64 vectors.
-}
 \usage{
 \method{format}{integer64}(x, justify="right", ...)
 
@@ -77,6 +74,9 @@
   \code{\link{sign}}, \code{\link{abs}}, \code{\link{floor}}, \code{\link{ceiling}}, \code{\link{trunc}} and
   \code{\link{round}} return a vector of class 'integer64' \cr
   \code{\link{signif}} is not implemented
+}
+\description{
+  Unary operators and functions for integer64 vectors.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/hashcache.Rd
+++ b/man/hashcache.Rd
@@ -6,9 +6,6 @@
 \title{
         Big caching of hashing, sorting, ordering
 }
-\description{
-    Functions to create cache that accelerates many operations
-}
 \usage{
 hashcache(x, nunique=NULL, ...)
 
@@ -38,15 +35,18 @@ set to 'memory' to minimize RAM requirements and sacrifice speed
         passed to \code{\link{hashmap}}
 }
 }
+\value{
+    \code{x} with a \code{\link{cache}} that contains the result of the expensive operations, possible together with small derived information (such as \code{\link{nunique.integer64}}) and previously cached results.
+}
+\description{
+    Functions to create cache that accelerates many operations
+}
 \details{
     The result of relative expensive operations \code{\link{hashmap}}, \code{\link[=ramsort.integer64]{ramsort}}, \code{\link[=ramsort.integer64]{ramsortorder}} and \code{\link[=ramsort.integer64]{ramorder}} can be stored in a cache in order to avoid multiple excutions. Unless in very specific situations, the recommended method is \code{hashsortorder} only.
 }
 \note{
   Note that we consider storing the big results from sorting and/or ordering as a relevant side-effect,
 and therefore storing them in the cache should require a conscious decision of the user.
-}
-\value{
-    \code{x} with a \code{\link{cache}} that contains the result of the expensive operations, possible together with small derived information (such as \code{\link{nunique.integer64}}) and previously cached results.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/hashcache.Rd
+++ b/man/hashcache.Rd
@@ -51,11 +51,11 @@ and therefore storing them in the cache should require a conscious decision of t
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-    \code{\link{cache}} for caching functions and \code{\link{nunique.integer64}} for methods benefiting from small caches
-}
 \examples{
     x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
  sortordercache(x)
+}
+\seealso{
+    \code{\link{cache}} for caching functions and \code{\link{nunique.integer64}} for methods benefiting from small caches
 }
 \keyword{ environment }

--- a/man/hashmap.Rd
+++ b/man/hashmap.Rd
@@ -122,9 +122,6 @@ re-use hashmaps, which avoid re-building hashmaps again and again.
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ programming }
-\keyword{ manip }
-\seealso{ \code{\link[=match.integer64]{match}}, \code{\link{runif64}} }
 \examples{
 x <- as.integer64(sample(c(NA, 0:9)))
 y <- as.integer64(sample(c(NA, 1:9), 10, TRUE))
@@ -182,3 +179,6 @@ stopifnot(identical(hashtab(hy), hashmaptab(y)))
     message("we conclude that n*sqrt(2) is enough to avoid collisions")
     }
 }
+\seealso{ \code{\link[=match.integer64]{match}}, \code{\link{runif64}} }
+\keyword{ programming }
+\keyword{ manip }

--- a/man/hashmap.Rd
+++ b/man/hashmap.Rd
@@ -28,12 +28,6 @@
 \title{
    Hashing for 64bit integers
 }
-\description{
-This is an explicit implementation of hash functionality that underlies
-matching and other functions in R. Explicit means that you can create,
-store and use hash functionality directly. One advantage is that you can
-re-use hashmaps, which avoid re-building hashmaps again and again.
-}
 \usage{
 hashfun(x, ...)
 
@@ -98,6 +92,15 @@ hashmaptab(x, ...)
   \item{keep.order}{ determines order of results and speed: \code{FALSE} (the default) is faster and returns in the (pseudo)random order of the hash function, \code{TRUE} returns in the order of first appearance in the original data, but this requires extra work }
   \item{...}{ further arguments, passed from generics, ignored in methods }
 }
+\value{
+  see details
+}
+\description{
+This is an explicit implementation of hash functionality that underlies
+matching and other functions in R. Explicit means that you can create,
+store and use hash functionality directly. One advantage is that you can
+re-use hashmaps, which avoid re-building hashmaps again and again.
+}
 \details{
 \tabular{rrl}{
    \bold{function} \tab \bold{see also}          \tab \bold{description} \cr
@@ -115,9 +118,6 @@ hashmaptab(x, ...)
    \code{hashtab} \tab \code{\link[=table.integer64]{table}} \tab tabulate values of hashdat using hashmap in \code{keep.order=FALSE} \cr
    \code{hashmaptab} \tab \code{\link[=table.integer64]{table}} \tab tabulate values of \code{x} building hasmap on the fly in \code{keep.order=FALSE}\cr
 }
-}
-\value{
-  see details
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/identical.integer64.Rd
+++ b/man/identical.integer64.Rd
@@ -32,11 +32,11 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{==.integer64}} \code{\link{identical}} \code{\link{integer64}}  }
 \examples{
   i64 <- as.double(NA); class(i64) <- "integer64"
   identical(i64-1, i64+1)
   identical.integer64(i64-1, i64+1)
 }
+\seealso{ \code{\link{==.integer64}} \code{\link{identical}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/identical.integer64.Rd
+++ b/man/identical.integer64.Rd
@@ -3,9 +3,6 @@
 \title{
    Identity function for class 'integer64'
 }
-\description{
-  This will discover any deviation between objects containing integer64 vectors.
-}
 \usage{
  identical.integer64(x, y
  , num.eq = FALSE, single.NA = FALSE, attrib.as.set = TRUE, ignore.bytecode = TRUE
@@ -23,11 +20,14 @@
   \item{ignore.srcref}{ see \code{\link{identical}} }
   \item{extptr.as.ref}{ see \code{\link{identical}} }
 }
-\details{
-  This is simply a wrapper to \code{\link{identical}} with default arguments \code{num.eq = FALSE, single.NA = FALSE}.
-}
 \value{
   A single logical value, \code{TRUE} or \code{FALSE}, never \code{NA} and never anything other than a single value.
+}
+\description{
+  This will discover any deviation between objects containing integer64 vectors.
+}
+\details{
+  This is simply a wrapper to \code{\link{identical}} with default arguments \code{num.eq = FALSE, single.NA = FALSE}.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/is.sorted.integer64.Rd
+++ b/man/is.sorted.integer64.Rd
@@ -51,9 +51,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-    \code{\link{cache}} for caching functions and \code{\link{sortordercache}} for functions creating big caches
-}
 \examples{
     x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
  length(x)
@@ -63,6 +60,9 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
  nties(x)
  table.integer64(x)
  x
+}
+\seealso{
+    \code{\link{cache}} for caching functions and \code{\link{sortordercache}} for functions creating big caches
 }
 \keyword{ environment }
 \keyword{ methods }

--- a/man/is.sorted.integer64.Rd
+++ b/man/is.sorted.integer64.Rd
@@ -7,9 +7,6 @@
 \title{
     Small cache access methods
 }
-\description{
-    These methods are packaged here for methods in packages \code{bit64} and \code{ff}.
-}
 \usage{
     \method{is.sorted}{integer64}(x, ...)
 
@@ -29,6 +26,12 @@
     ignored
     }
 }
+\value{
+    \code{is.sorted} returns a logical scalar, the other methods return an integer scalar.
+}
+\description{
+    These methods are packaged here for methods in packages \code{bit64} and \code{ff}.
+}
 \details{
   All these functions benefit from a \code{\link{sortcache}}, \code{\link{ordercache}} or \code{\link{sortordercache}}.
   \code{na.count}, \code{nvalid} and \code{nunique} also benefit from a \code{\link{hashcache}}.
@@ -44,9 +47,6 @@
  then these functions will store their result in the cache.
  We do not consider this a relevant side-effect,
  since these small cache results do not have a relevant memory footprint.
-}
-\value{
-    \code{is.sorted} returns a logical scalar, the other methods return an integer scalar.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/keypos.Rd
+++ b/man/keypos.Rd
@@ -30,14 +30,14 @@ and \code{\link{orderkey}} (memory saving ordering).
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{unique.integer64}} for the unique subset and \code{\link{match.integer64}} for finding positions in a different vector.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 keypos(x)
 
 stopifnot(identical(keypos(x),  match.integer64(x, sort(unique(x), na.last=FALSE))))
+}
+\seealso{
+  \code{\link{unique.integer64}} for the unique subset and \code{\link{match.integer64}} for finding positions in a different vector.
 }
 \keyword{manip}
 \keyword{univar}

--- a/man/keypos.Rd
+++ b/man/keypos.Rd
@@ -2,9 +2,6 @@
 \alias{keypos}
 \alias{keypos.integer64}
 \title{Extract Positions in redundant dimension table}
-\description{
-  \code{keypos} returns the positions of the (fact table) elements that participate in their sorted unique subset (dimension table)
-}
 \usage{
 keypos(x, ...)
 
@@ -17,15 +14,18 @@ keypos(x, ...)
 }
   \item{...}{ignored}
 }
+\value{
+  an integer vector of the same length as \code{x} containing positions relativ to \code{sort(unique(x), na.last=FALSE)}
+}
+\description{
+  \code{keypos} returns the positions of the (fact table) elements that participate in their sorted unique subset (dimension table)
+}
 \details{
   NAs are sorted first in the dimension table, see \code{\link{ramorder.integer64}}.
   \cr
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{sortorderkey}} (fast ordering)
 and \code{\link{orderkey}} (memory saving ordering).
-}
-\value{
-  an integer vector of the same length as \code{x} containing positions relativ to \code{sort(unique(x), na.last=FALSE)}
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/match.integer64.Rd
+++ b/man/match.integer64.Rd
@@ -4,12 +4,6 @@
 \title{
 64-bit integer matching
 }
-\description{
-\code{match} returns a vector of the positions of (first) matches of its first argument in its second.
-
-\code{\%in\%} is a more intuitive interface as a binary operator, which returns a logical vector indicating if there is a match or not for its left operand.
-
-}
 \usage{
 \method{match}{integer64}(x, table, nomatch = NA_integer_, nunique = NULL, method = NULL, ...)
 
@@ -35,13 +29,6 @@
 ignored
 }
 }
-\details{
-  These functions automatically choose from several low-level functions considering the size of \code{x} and \code{table} and the availability of caches.
-
-
-  Suitable methods for \code{\%in\%.integer64} are \code{\link{hashpos}} (hash table lookup), \code{\link{hashrev}} (reverse lookup), \code{\link{sortorderpos}} (fast ordering) and \code{\link{orderpos}} (memory saving ordering).
-  Suitable methods for \code{match.integer64} are \code{\link{hashfin}} (hash table lookup), \code{\link{hashrin}} (reverse lookup), \code{\link{sortfin}} (fast sorting) and \code{\link{orderfin}} (memory saving ordering).
-}
 \value{
   A vector of the same length as \code{x}.
 
@@ -56,6 +43,19 @@ ignored
   \code{\%in\%}: A logical vector, indicating if a match was located for
   each element of \code{x}: thus the values are \code{TRUE} or
   \code{FALSE} and never \code{NA}.
+}
+\description{
+\code{match} returns a vector of the positions of (first) matches of its first argument in its second.
+
+\code{\%in\%} is a more intuitive interface as a binary operator, which returns a logical vector indicating if there is a match or not for its left operand.
+
+}
+\details{
+  These functions automatically choose from several low-level functions considering the size of \code{x} and \code{table} and the availability of caches.
+
+
+  Suitable methods for \code{\%in\%.integer64} are \code{\link{hashpos}} (hash table lookup), \code{\link{hashrev}} (reverse lookup), \code{\link{sortorderpos}} (fast ordering) and \code{\link{orderpos}} (memory saving ordering).
+  Suitable methods for \code{match.integer64} are \code{\link{hashfin}} (hash table lookup), \code{\link{hashrin}} (reverse lookup), \code{\link{sortfin}} (fast sorting) and \code{\link{orderfin}} (memory saving ordering).
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/match.integer64.Rd
+++ b/man/match.integer64.Rd
@@ -60,9 +60,6 @@ ignored
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-    \code{\link{match}}
-}
 \examples{
 x <- as.integer64(c(NA, 0:9), 32)
 table <- as.integer64(c(1:9, NA))
@@ -121,6 +118,9 @@ stopifnot(identical("\%in\%.integer64"(x, table), as.integer(x) \%in\% as.intege
       print(apply(tim, 1:2, function(ti)if(any(is.na(ti)))NA else which.min(ti)))
     }
 }
+}
+\seealso{
+    \code{\link{match}}
 }
 \keyword{manip}
 \keyword{logic}

--- a/man/optimizer64.data.Rd
+++ b/man/optimizer64.data.Rd
@@ -4,9 +4,6 @@
 \title{
  Results of performance measurement on a Core i7 Lenovo T410 8 GB RAM under Windows 7 64bit
 }
-\description{
-  These are the results of calling \code{\link{optimizer64}}
-}
 \usage{data(optimizer64.data)}
 \format{
   The format is:
@@ -79,6 +76,9 @@ List of 16
  - attr(*, "dimnames")=List of 2
   ..$ : chr [1:8] "match" "\%in\%" "duplicated" "unique" ...
   ..$ : chr [1:2] "65536" "33554432"
+}
+\description{
+  These are the results of calling \code{\link{optimizer64}}
 }
 \examples{
 data(optimizer64.data)

--- a/man/optimizer64.data.Rd
+++ b/man/optimizer64.data.Rd
@@ -4,7 +4,6 @@
 \title{
  Results of performance measurement on a Core i7 Lenovo T410 8 GB RAM under Windows 7 64bit
 }
-\usage{data(optimizer64.data)}
 \format{
   The format is:
 List of 16
@@ -77,6 +76,7 @@ List of 16
   ..$ : chr [1:8] "match" "\%in\%" "duplicated" "unique" ...
   ..$ : chr [1:2] "65536" "33554432"
 }
+\usage{data(optimizer64.data)}
 \description{
   These are the results of calling \code{\link{optimizer64}}
 }

--- a/man/optimizer64.data.Rd
+++ b/man/optimizer64.data.Rd
@@ -1,6 +1,6 @@
+\docType{data}
 \name{optimizer64.data}
 \alias{optimizer64.data}
-\docType{data}
 \title{
  Results of performance measurement on a Core i7 Lenovo T410 8 GB RAM under Windows 7 64bit
 }

--- a/man/plusclass.Rd
+++ b/man/plusclass.Rd
@@ -22,13 +22,13 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\keyword{ internal }
-\seealso{
-  \code{\link{oldClass}} \code{\link{integer64}}
-}
 \examples{
   plusclass("inheritingclass","integer64")
   minusclass(c("inheritingclass","integer64"), "integer64")
 }
+\seealso{
+  \code{\link{oldClass}} \code{\link{integer64}}
+}
+\keyword{ classes }
+\keyword{ manip }
+\keyword{ internal }

--- a/man/plusclass.Rd
+++ b/man/plusclass.Rd
@@ -4,9 +4,6 @@
 \title{
    integer64: Maintaining S3 class attribute
 }
-\description{
-  Maintaining integer64 S3 class attribute.
-}
 \usage{
   plusclass(class, whichclass)
 
@@ -18,6 +15,9 @@
 }
 \value{
   NULL or a character vector of class attributes
+}
+\description{
+  Maintaining integer64 S3 class attribute.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/prank.Rd
+++ b/man/prank.Rd
@@ -2,10 +2,6 @@
 \alias{prank}
 \alias{prank.integer64}
 \title{(P)ercent (Rank)s}
-\description{
-    Function \code{prank.integer64}  projects the values [min..max] via ranks [1..n] to [0..1].
-    \code{\link{qtile.integer64}} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
-}
 \usage{
     prank(x, ...)
 
@@ -18,11 +14,15 @@
 }
   \item{...}{ignored}
 }
-\details{
-    Function \code{prank.integer64} is based on \code{\link{rank.integer64}}.
-}
 \value{
   \code{prank} returns a numeric vector of the same length as \code{x}.
+}
+\description{
+    Function \code{prank.integer64}  projects the values [min..max] via ranks [1..n] to [0..1].
+    \code{\link{qtile.integer64}} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
+}
+\details{
+    Function \code{prank.integer64} is based on \code{\link{rank.integer64}}.
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/prank.Rd
+++ b/man/prank.Rd
@@ -27,14 +27,14 @@
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{rank.integer64}} for simple ranks and \code{\link{qtile}} for the inverse function quantiles.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 prank(x)
 
 x <- x[!is.na(x)]
 stopifnot(identical(x,  unname(qtile(x, probs=prank(x)))))
+}
+\seealso{
+  \code{\link{rank.integer64}} for simple ranks and \code{\link{qtile}} for the inverse function quantiles.
 }
 \keyword{univar}

--- a/man/qtile.Rd
+++ b/man/qtile.Rd
@@ -6,10 +6,6 @@
 \alias{mean.integer64}
 \alias{summary.integer64}
 \title{(Q)uan(Tile)s }
-\description{
-    Function \code{\link{prank.integer64}}  projects the values [min..max] via ranks [1..n] to [0..1].
-    \code{qtile.ineger64} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
-}
 \usage{
     qtile(x, probs=seq(0, 1, 0.25), ...)
 
@@ -46,6 +42,16 @@
 }
   \item{...}{ignored}
 }
+\value{
+  \code{prank} returns a numeric vector of the same length as \code{x}.
+  \cr
+  \code{qtile} returns a vector with elements from \code{x}
+  at the relative positions specified by \code{probs}.
+}
+\description{
+    Function \code{\link{prank.integer64}}  projects the values [min..max] via ranks [1..n] to [0..1].
+    \code{qtile.ineger64} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
+}
 \details{
  Functions \code{quantile.integer64} with \code{type=0} and \code{median.integer64} are convenience wrappers to \code{qtile}.
  \cr
@@ -59,12 +65,6 @@
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{sortqtl}} (fast sorting)
 and \code{\link{orderqtl}} (memory saving ordering).
-}
-\value{
-  \code{prank} returns a numeric vector of the same length as \code{x}.
-  \cr
-  \code{qtile} returns a vector with elements from \code{x}
-  at the relative positions specified by \code{probs}.
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/qtile.Rd
+++ b/man/qtile.Rd
@@ -69,9 +69,6 @@ and \code{\link{orderqtl}} (memory saving ordering).
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{rank.integer64}} for simple ranks and \code{\link{quantile}} for quantiles.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 qtile(x, probs=seq(0, 1, 0.25))
@@ -81,5 +78,8 @@ summary(x)
 
 x <- x[!is.na(x)]
 stopifnot(identical(x,  unname(qtile(x, probs=prank(x)))))
+}
+\seealso{
+  \code{\link{rank.integer64}} for simple ranks and \code{\link{quantile}} for quantiles.
 }
 \keyword{univar}

--- a/man/ramsort.integer64.Rd
+++ b/man/ramsort.integer64.Rd
@@ -17,10 +17,6 @@
 \title{
    Low-level intger64 methods for in-RAM sorting and ordering
 }
-\description{
-  Fast low-level methods for sorting and ordering.
-  The \code{..sortorder} methods do sorting and ordering at once, which requires more RAM than ordering but is (almost) as fast as as sorting.
-}
 \note{
  Note that these methods purposely violate the functional programming paradigm: they are called for the side-effect of changing some of their arguments.
  The \code{sort}-methods change \code{x}, the \code{order}-methods change \code{i}, and the \code{sortoder}-methods change both \code{x} and \code{i}
@@ -94,11 +90,15 @@ number of remaining recursionlevels before \code{quicksort} switches from recurs
 }
   \item{...}{ further arguments, passed from generics, ignored in methods }
 }
-\details{
- see \code{\link[bit:Sorting]{ramsort}}
-}
 \value{
   These functions return the number of \code{NAs} found or assumed during sorting
+}
+\description{
+  Fast low-level methods for sorting and ordering.
+  The \code{..sortorder} methods do sorting and ordering at once, which requires more RAM than ordering but is (almost) as fast as as sorting.
+}
+\details{
+ see \code{\link[bit:Sorting]{ramsort}}
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/ramsort.integer64.Rd
+++ b/man/ramsort.integer64.Rd
@@ -17,10 +17,6 @@
 \title{
    Low-level intger64 methods for in-RAM sorting and ordering
 }
-\note{
- Note that these methods purposely violate the functional programming paradigm: they are called for the side-effect of changing some of their arguments.
- The \code{sort}-methods change \code{x}, the \code{order}-methods change \code{i}, and the \code{sortoder}-methods change both \code{x} and \code{i}
-}
 \usage{
 \method{shellsort}{integer64}(x, has.na=TRUE, na.last=FALSE, decreasing=FALSE, ...)
 
@@ -99,6 +95,10 @@ number of remaining recursionlevels before \code{quicksort} switches from recurs
 }
 \details{
  see \code{\link[bit:Sorting]{ramsort}}
+}
+\note{
+ Note that these methods purposely violate the functional programming paradigm: they are called for the side-effect of changing some of their arguments.
+ The \code{sort}-methods change \code{x}, the \code{order}-methods change \code{i}, and the \code{sortoder}-methods change both \code{x} and \code{i}
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/ramsort.integer64.Rd
+++ b/man/ramsort.integer64.Rd
@@ -103,9 +103,6 @@ number of remaining recursionlevels before \code{quicksort} switches from recurs
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ programming }
-\keyword{ manip }
-\seealso{ \code{\link[bit:Sorting]{ramsort}} for the generic, \code{ramsort.default} for the methods provided by package \code{ff}, \code{\link{sort.integer64}} for the sort interface and \code{\link{sortcache}} for caching the work of sorting}
 \examples{
   x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
   x
@@ -129,3 +126,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   s
   o
 }
+\seealso{ \code{\link[bit:Sorting]{ramsort}} for the generic, \code{ramsort.default} for the methods provided by package \code{ff}, \code{\link{sort.integer64}} for the sort interface and \code{\link{sortcache}} for caching the work of sorting}
+\keyword{ programming }
+\keyword{ manip }

--- a/man/rank.integer64.Rd
+++ b/man/rank.integer64.Rd
@@ -1,10 +1,6 @@
 \name{rank.integer64}
 \alias{rank.integer64}
 \title{Sample Ranks from integer64}
-\description{
-  Returns the sample ranks of the values in a vector.  Ties (i.e., equal
-  values) are averaged and missing values propagated.
-}
 \usage{
     \method{rank}{integer64}(x, method = NULL, ...)
 }
@@ -15,13 +11,17 @@
 }
   \item{...}{ignored}
 }
+\value{
+  A numeric vector of the same length as \code{x}.
+}
+\description{
+  Returns the sample ranks of the values in a vector.  Ties (i.e., equal
+  values) are averaged and missing values propagated.
+}
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{sortorderrnk}} (fast ordering)
 and \code{\link{orderrnk}} (memory saving ordering).
-}
-\value{
-  A numeric vector of the same length as \code{x}.
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/rank.integer64.Rd
+++ b/man/rank.integer64.Rd
@@ -26,14 +26,14 @@ and \code{\link{orderrnk}} (memory saving ordering).
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{order.integer64}}, \code{\link{rank}} and \code{\link{prank}} for percent rank.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 rank.integer64(x)
 
 stopifnot(identical(rank.integer64(x),  rank(as.integer(x)
 , na.last="keep", ties.method = "average")))
+}
+\seealso{
+  \code{\link{order.integer64}}, \code{\link{rank}} and \code{\link{prank}} for percent rank.
 }
 \keyword{univar}

--- a/man/rep.integer64.Rd
+++ b/man/rep.integer64.Rd
@@ -3,9 +3,6 @@
 \title{
    Replicate elements of integer64 vectors
 }
-\description{
-  Replicate elements of integer64 vectors
-}
 \usage{
 \method{rep}{integer64}(x, ...)
 }
@@ -15,6 +12,9 @@
 }
 \value{
   \code{\link{rep}} returns a integer64 vector
+}
+\description{
+  Replicate elements of integer64 vectors
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/rep.integer64.Rd
+++ b/man/rep.integer64.Rd
@@ -19,13 +19,13 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{c.integer64}} \code{\link{rep.integer64}}
-          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
-}
 \examples{
   rep(as.integer64(1:2), 6)
   rep(as.integer64(1:2), c(6,6))
   rep(as.integer64(1:2), length.out=6)
 }
+\seealso{ \code{\link{c.integer64}} \code{\link{rep.integer64}}
+          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
+}
+\keyword{ classes }
+\keyword{ manip }

--- a/man/runif64.Rd
+++ b/man/runif64.Rd
@@ -3,9 +3,6 @@
 \title{
    integer64: random numbers
 }
-\description{
-  Create uniform random 64-bit integers within defined range
-}
 \usage{
   runif64(n, min = lim.integer64()[1], max = lim.integer64()[2], replace=TRUE)
 }
@@ -17,6 +14,9 @@
 }
 \value{
   a integer64 vector
+}
+\description{
+  Create uniform random 64-bit integers within defined range
 }
 \details{
   For each random integer we call R's internal C interface \code{unif_rand()} twice.

--- a/man/runif64.Rd
+++ b/man/runif64.Rd
@@ -26,12 +26,6 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{distribution}
-\keyword{sysdata}
-\seealso{
-  \code{\link{runif}}, \code{\link{hashfun}}
-}
 \examples{
   runif64(12)
   runif64(12, -16, 16)
@@ -44,3 +38,9 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   table(sample(16, replace=TRUE))
   table(runif64(16, 1, 16, replace=TRUE))
 }
+\seealso{
+  \code{\link{runif}}, \code{\link{hashfun}}
+}
+\keyword{ classes }
+\keyword{distribution}
+\keyword{sysdata}

--- a/man/seq.integer64.Rd
+++ b/man/seq.integer64.Rd
@@ -3,9 +3,6 @@
 \title{
    integer64: Sequence Generation
 }
-\description{
-  Generating sequence of integer64 values
-}
 \usage{
 \method{seq}{integer64}(from = NULL, to = NULL, by = NULL, length.out = NULL, along.with = NULL, ...)
 }
@@ -17,13 +14,16 @@
   \item{along.with}{ scalar }
   \item{...}{ ignored }
 }
+\value{
+  an integer64 vector with the generated sequence
+}
+\description{
+  Generating sequence of integer64 values
+}
 \details{
   \code{seq.integer64} does coerce its arguments 'from', 'to' and 'by' to \code{integer64}.
   If not provided, the argument 'by' is automatically determined as \code{+1} or \code{-1},
   but the size of 'by' is not calculated as in \code{\link{seq}} (because this might result in a non-integer value).
-}
-\value{
-  an integer64 vector with the generated sequence
 }
 \note{
   In base R \code{\link{:}} currently is not generic and does not dispatch, see section "Limitations inherited from Base R" in \code{\link{integer64}}

--- a/man/seq.integer64.Rd
+++ b/man/seq.integer64.Rd
@@ -31,13 +31,13 @@
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{c.integer64}} \code{\link{rep.integer64}}
-          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
-}
 \examples{
   # colon not activated: as.integer64(1):12
   seq(as.integer64(1), 12, 2)
   seq(as.integer64(1), by=2, length.out=6)
 }
+\seealso{ \code{\link{c.integer64}} \code{\link{rep.integer64}}
+          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
+}
+\keyword{ classes }
+\keyword{ manip }

--- a/man/sort.integer64.Rd
+++ b/man/sort.integer64.Rd
@@ -49,9 +49,6 @@ set to 'memory' to minimize RAM requirements and sacrifice speed
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ programming }
-\keyword{ manip }
-\seealso{ \code{\link[=sort.integer64]{sort}}, \code{\link{sortcache}} }
 \examples{
   x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
   x
@@ -62,3 +59,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   message("slower with less RAM, this calls 'ramsortorder'")
   order.integer64(x, optimize="memory")
 }
+\seealso{ \code{\link[=sort.integer64]{sort}}, \code{\link{sortcache}} }
+\keyword{ programming }
+\keyword{ manip }

--- a/man/sort.integer64.Rd
+++ b/man/sort.integer64.Rd
@@ -4,10 +4,6 @@
 \title{
    High-level intger64 methods for sorting and ordering
 }
-\description{
-  Fast high-level methods for sorting and ordering.
-  These are wrappers to \code{\link{ramsort.integer64}} and friends and do not modify their arguments.
-}
 \usage{
 \method{sort}{integer64}(x, decreasing = FALSE, has.na = TRUE, na.last = TRUE, stable = TRUE
 , optimize = c("time", "memory"), VERBOSE = FALSE, ...)
@@ -40,11 +36,15 @@ set to 'memory' to minimize RAM requirements and sacrifice speed
 }
   \item{...}{ further arguments, passed from generics, ignored in methods }
 }
-\details{
- see \code{\link{sort}} and \code{\link{order}}
-}
 \value{
   \code{sort} returns the sorted vector and \code{vector} returns the order positions.
+}
+\description{
+  Fast high-level methods for sorting and ordering.
+  These are wrappers to \code{\link{ramsort.integer64}} and friends and do not modify their arguments.
+}
+\details{
+ see \code{\link{sort}} and \code{\link{order}}
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/sortnut.Rd
+++ b/man/sortnut.Rd
@@ -50,10 +50,6 @@
 \title{
    Searching and other uses of sorting for 64bit integers
 }
-\description{
-  This is roughly an implementation of hash functionality but based on sorting instead on a hasmap.
-  Since sorting is more informative than hashingwe can do some more interesting things.
-}
 \usage{
 sortnut(sorted, ...)
 
@@ -163,6 +159,13 @@ sortorderrnk(sorted, order, na.count, ...)
   \item{method}{ see details }
   \item{...}{ further arguments, passed from generics, ignored in methods }
 }
+\value{
+  see details
+}
+\description{
+  This is roughly an implementation of hash functionality but based on sorting instead on a hasmap.
+  Since sorting is more informative than hashingwe can do some more interesting things.
+}
 \details{
 \tabular{rrrrl}{
    \bold{sortfun} \tab \bold{orderfun} \tab \bold{sortorderfun} \tab \bold{see also}          \tab \bold{description} \cr
@@ -188,9 +191,6 @@ The functions \code{orderdup} and \code{sortorderdup} each offer two algorithms 
 With \code{method=1L} the return values are set directly which causes random write access on a possibly large return vector. \cr
 With \code{method=2L} the return values are first set in a smaller bit-vector -- random access limited to a smaller memory region -- and finally written sequentially to the logical output  vector. \cr
 With \code{method=NULL} the functions use a heuristic to determine the fastest algorithm. \cr
-}
-\value{
-  see details
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/sortnut.Rd
+++ b/man/sortnut.Rd
@@ -195,10 +195,10 @@ With \code{method=NULL} the functions use a heuristic to determine the fastest a
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ programming }
-\keyword{ manip }
-\seealso{ \code{\link[=match.integer64]{match}} }
 \examples{
  message("check the code of 'optimizer64' for examples:")
  print(optimizer64)
 }
+\seealso{ \code{\link[=match.integer64]{match}} }
+\keyword{ programming }
+\keyword{ manip }

--- a/man/sum.integer64.Rd
+++ b/man/sum.integer64.Rd
@@ -10,10 +10,6 @@
 \title{
    Summary functions for integer64 vectors
 }
-\description{
-  Summary functions for integer64 vectors.
-  Function 'range' without arguments returns the smallest and largest value of the 'integer64' class.
-}
 \usage{
 \method{all}{integer64}(..., na.rm = FALSE)
 
@@ -36,6 +32,15 @@ lim.integer64()
   \item{na.rm}{ logical scalar indicating whether to ignore NAs }
   \item{finite}{ logical scalar indicating whether to ignore NAs (just for compatibility with \code{\link{range.default}}) }
 }
+\value{
+  \code{\link{all}} and \code{\link{any}} return a logical scalar\cr
+  \code{\link{range}} returns a integer64 vector with two elements\cr
+  \code{\link{min}}, \code{\link{max}}, \code{\link{sum}} and \code{\link{prod}} return a integer64 scalar
+}
+\description{
+  Summary functions for integer64 vectors.
+  Function 'range' without arguments returns the smallest and largest value of the 'integer64' class.
+}
 \details{
   The numerical summary methods always return \code{integer64}.
   Therefor the methods for \code{min},\code{max} and \code{range} do not return \code{+Inf,-Inf}
@@ -43,11 +48,6 @@ lim.integer64()
   The same is true if only  \code{NA}s are submitted with argument \code{na.rm=TRUE}.
  \cr
   \code{lim.integer64} returns these limits in proper order \code{-9223372036854775807, +9223372036854775807} and without a \code{\link{warning}}.
-}
-\value{
-  \code{\link{all}} and \code{\link{any}} return a logical scalar\cr
-  \code{\link{range}} returns a integer64 vector with two elements\cr
-  \code{\link{min}}, \code{\link{max}}, \code{\link{sum}} and \code{\link{prod}} return a integer64 scalar
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/sum.integer64.Rd
+++ b/man/sum.integer64.Rd
@@ -52,10 +52,10 @@ lim.integer64()
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{mean.integer64}} \code{\link{cumsum.integer64}} \code{\link{integer64}}  }
 \examples{
   lim.integer64()
   range(as.integer64(1:12))
 }
+\seealso{ \code{\link{mean.integer64}} \code{\link{cumsum.integer64}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/table.integer64.Rd
+++ b/man/table.integer64.Rd
@@ -2,11 +2,6 @@
 \alias{table.integer64}
 \title{Cross Tabulation and Table Creation for integer64}
 
-\concept{counts}
-\concept{frequencies}
-\concept{occurrences}
-\concept{contingency table}
-
 \usage{
 table.integer64(...
 , return = c("table","data.frame","list")
@@ -107,4 +102,8 @@ table.integer64(x, as.integer64(as.factor(z)))
 \seealso{
   \code{\link{table}} for more info on the standard version coping with Base R's data types, \code{\link{tabulate}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, \code{\link{unique.integer64}} for the unique values without counting them and \code{\link{unipos.integer64}} for the positions of the unique values.
 }
+\concept{counts}
+\concept{frequencies}
+\concept{occurrences}
+\concept{contingency table}
 \keyword{category}

--- a/man/table.integer64.Rd
+++ b/man/table.integer64.Rd
@@ -76,9 +76,6 @@ and \code{\link{ordertab}} (memory saving ordering).
   Note that by using \code{\link{as.integer64.factor}} we can also input
   factors into \code{table.integer64} -- only the \code{\link{levels}} get lost.
 }
-\seealso{
-  \code{\link{table}} for more info on the standard version coping with Base R's data types, \code{\link{tabulate}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, \code{\link{unique.integer64}} for the unique values without counting them and \code{\link{unipos.integer64}} for the positions of the unique values.
-}
 \examples{
 message("pure integer64 examples")
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
@@ -106,5 +103,8 @@ table.integer64(x, as.integer64(as.factor(z)))
  stopifnot(identical(table(c(1,1,2),as.integer64(c(3,4,4))), table(c(1,1,2),c(3,4,4))))
 }
 
+}
+\seealso{
+  \code{\link{table}} for more info on the standard version coping with Base R's data types, \code{\link{tabulate}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, \code{\link{unique.integer64}} for the unique values without counting them and \code{\link{unipos.integer64}} for the positions of the unique values.
 }
 \keyword{category}

--- a/man/table.integer64.Rd
+++ b/man/table.integer64.Rd
@@ -1,6 +1,6 @@
 \name{table.integer64}
-\title{Cross Tabulation and Table Creation for integer64}
 \alias{table.integer64}
+\title{Cross Tabulation and Table Creation for integer64}
 
 \concept{counts}
 \concept{frequencies}

--- a/man/table.integer64.Rd
+++ b/man/table.integer64.Rd
@@ -7,10 +7,6 @@
 \concept{occurrences}
 \concept{contingency table}
 
-\description{
-  \code{table.integer64} uses the cross-classifying integer64 vectors to build a contingency
-  table of the counts at each combination of vector values.
-}
 \usage{
 table.integer64(...
 , return = c("table","data.frame","list")
@@ -42,6 +38,24 @@ table.integer64(...
   \item{deparse.level}{controls how the default \code{dnn} is
     constructed.  See \sQuote{Details}.}
 }
+\value{
+  By default (with \code{return="table"}) \code{\link{table}} returns a \emph{contingency table}, an object of
+  class \code{"table"}, an array of integer values. Note that unlike S the result is always an array, a 1D array if one factor is given. Note also that for multidimensional arrays this is a \emph{dense} return structure which can dramatically increase RAM requirements (for large arrays with high mutual information, i.e. many possible input combinations of which only few occur) and that \code{\link{table}} is limited to \code{2^31} possible combinations (e.g. two input vectors with 46340 unique values only). Finally note that the tabulated values or value-combinations are represented as \code{dimnames} and that the implied conversion of values to strings can cause \emph{severe} performance problems since each string needs to be integrated into R's global string cache.
+  \cr
+  You can use the other \code{return=} options to cope with these problems, the potential combination limit is increased from \code{2^31} to \code{2^63} with these options, RAM is only rewquired for observed combinations and string conversion is avoided.
+  \cr
+  With \code{return="data.frame"} you get a \emph{dense} representation as a \code{\link{data.frame}} (like that resulting from \code{as.data.frame(table(...))}) where only observed combinations are listed (each as a data.frame row) with the corresponding frequency counts (the latter as component
+  named by \code{responseName}).  This is the inverse of \code{\link{xtabs}}..
+  \cr
+  With \code{return="list"} you also get a \emph{dense} representation as a simple \code{\link{list}} with components
+  \item{values }{a integer64 vector of the technically tabulated values, for 1D this is the tabulated values themselves, for kD these are the values representing the potential combinations of input values}
+  \item{counts}{the frequency counts}
+  \item{dims}{only for kD: a list with the vectors of the unique values of the input dimensions}
+}
+\description{
+  \code{table.integer64} uses the cross-classifying integer64 vectors to build a contingency
+  table of the counts at each combination of vector values.
+}
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{hashmaptab}} (simultaneously creating and using a hashmap)
@@ -57,20 +71,6 @@ and \code{\link{ordertab}} (memory saving ordering).
   and \code{deparse.level = 2} will deparse the argument.
 
   Arguments \code{exclude}, \code{useNA}, are not supported, i.e. \code{NA}s are always tabulated, and, different from \code{\link{table}} they are sorted first if \code{order="values"}.
-}
-\value{
-  By default (with \code{return="table"}) \code{\link{table}} returns a \emph{contingency table}, an object of
-  class \code{"table"}, an array of integer values. Note that unlike S the result is always an array, a 1D array if one factor is given. Note also that for multidimensional arrays this is a \emph{dense} return structure which can dramatically increase RAM requirements (for large arrays with high mutual information, i.e. many possible input combinations of which only few occur) and that \code{\link{table}} is limited to \code{2^31} possible combinations (e.g. two input vectors with 46340 unique values only). Finally note that the tabulated values or value-combinations are represented as \code{dimnames} and that the implied conversion of values to strings can cause \emph{severe} performance problems since each string needs to be integrated into R's global string cache.
-  \cr
-  You can use the other \code{return=} options to cope with these problems, the potential combination limit is increased from \code{2^31} to \code{2^63} with these options, RAM is only rewquired for observed combinations and string conversion is avoided.
-  \cr
-  With \code{return="data.frame"} you get a \emph{dense} representation as a \code{\link{data.frame}} (like that resulting from \code{as.data.frame(table(...))}) where only observed combinations are listed (each as a data.frame row) with the corresponding frequency counts (the latter as component
-  named by \code{responseName}).  This is the inverse of \code{\link{xtabs}}..
-  \cr
-  With \code{return="list"} you also get a \emph{dense} representation as a simple \code{\link{list}} with components
-  \item{values }{a integer64 vector of the technically tabulated values, for 1D this is the tabulated values themselves, for kD these are the values representing the potential combinations of input values}
-  \item{counts}{the frequency counts}
-  \item{dims}{only for kD: a list with the vectors of the unique values of the input dimensions}
 }
 \note{
   Note that by using \code{\link{as.integer64.factor}} we can also input

--- a/man/tiepos.Rd
+++ b/man/tiepos.Rd
@@ -2,9 +2,6 @@
 \alias{tiepos}
 \alias{tiepos.integer64}
 \title{Extract Positions of Tied Elements}
-\description{
-  \code{tiepos} returns the positions of those elements that participate in ties.
-}
 \usage{
 tiepos(x, ...)
 
@@ -20,13 +17,16 @@ tiepos(x, ...)
 }
   \item{...}{ignored}
 }
+\value{
+  an integer vector of positions
+}
+\description{
+  \code{tiepos} returns the positions of those elements that participate in ties.
+}
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{sortordertie}} (fast ordering)
 and \code{\link{ordertie}} (memory saving ordering).
-}
-\value{
-  an integer vector of positions
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/tiepos.Rd
+++ b/man/tiepos.Rd
@@ -31,14 +31,14 @@ and \code{\link{ordertie}} (memory saving ordering).
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{rank.integer64}} for possibly tied ranks and \code{\link{unipos.integer64}} for positions of unique values.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 tiepos(x)
 
 stopifnot(identical(tiepos(x),  (1:length(x))[duplicated(x) | rev(duplicated(rev(x)))]))
+}
+\seealso{
+  \code{\link{rank.integer64}} for possibly tied ranks and \code{\link{unipos.integer64}} for positions of unique values.
 }
 \keyword{manip}
 \keyword{univar}

--- a/man/unipos.Rd
+++ b/man/unipos.Rd
@@ -2,9 +2,6 @@
 \alias{unipos}
 \alias{unipos.integer64}
 \title{Extract Positions of Unique Elements}
-\description{
-  \code{unipos} returns the positions of those elements returned by \code{\link{unique}}.
-}
 \usage{
 unipos(x, incomparables = FALSE, order = c("original","values","any"), ...)
 
@@ -23,6 +20,12 @@ unipos(x, incomparables = FALSE, order = c("original","values","any"), ...)
 }
   \item{...}{ignored}
 }
+\value{
+  an integer vector of positions
+}
+\description{
+  \code{unipos} returns the positions of those elements returned by \code{\link{unique}}.
+}
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{hashmapupo}} (simultaneously creating and using a hashmap)
@@ -33,9 +36,6 @@ and \code{\link{orderupo}} (memory saving ordering).
 The default \code{order="original"} collects unique values in the order of the first appearance in \code{x} like in \code{\link{unique}}, this costs extra processing.
 \code{order="values"} collects unique values in sorted order like in \code{\link{table}}, this costs extra processing with the hash methods but comes for free.
 \code{order="any"} collects unique values in undefined order, possibly faster. For hash methods this will be a quasi random order, for sort methods this will be sorted order.
-}
-\value{
-  an integer vector of positions
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/unipos.Rd
+++ b/man/unipos.Rd
@@ -40,9 +40,6 @@ The default \code{order="original"} collects unique values in the order of the f
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{unique.integer64}} for unique values and \code{\link{match.integer64}} for general matching.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 unipos(x)
@@ -53,6 +50,9 @@ stopifnot(identical(unipos(x),  match.integer64(unique(x), x)))
 stopifnot(identical(unipos(x, order="values"),  match.integer64(unique(x, order="values"), x)))
 stopifnot(identical(unique(x),  x[unipos(x)]))
 stopifnot(identical(unique(x, order="values"),  x[unipos(x, order="values")]))
+}
+\seealso{
+  \code{\link{unique.integer64}} for unique values and \code{\link{match.integer64}} for general matching.
 }
 \keyword{manip}
 \keyword{logic}

--- a/man/unique.integer64.Rd
+++ b/man/unique.integer64.Rd
@@ -1,9 +1,6 @@
 \name{unique.integer64}
 \alias{unique.integer64}
 \title{Extract Unique Elements from integer64}
-\description{
-  \code{unique} returns a vector like \code{x} but with duplicate elements/rows removed.
-}
 \usage{
 \method{unique}{integer64}(x, incomparables = FALSE, order = c("original","values","any")
 , nunique = NULL, method = NULL, ...)
@@ -20,6 +17,14 @@
 }
   \item{...}{ignored}
 }
+\value{
+  For a vector, an object of the same type of \code{x}, but with only
+  one copy of each duplicated element.  No attributes are copied (so
+  the result has no names).
+}
+\description{
+  \code{unique} returns a vector like \code{x} but with duplicate elements/rows removed.
+}
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{hashmapuni}} (simultaneously creating and using a hashmap)
@@ -31,11 +36,6 @@ and \code{\link{orderuni}} (memory saving ordering).
 The default \code{order="original"} returns unique values in the order of the first appearance in \code{x} like in \code{\link{unique}}, this costs extra processing.
 \code{order="values"} returns unique values in sorted order like in \code{\link{table}}, this costs extra processing with the hash methods but comes for free.
 \code{order="any"} returns unique values in undefined order, possibly faster. For hash methods this will be a quasi random order, for sort methods this will be sorted order.
-}
-\value{
-  For a vector, an object of the same type of \code{x}, but with only
-  one copy of each duplicated element.  No attributes are copied (so
-  the result has no names).
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/unique.integer64.Rd
+++ b/man/unique.integer64.Rd
@@ -40,10 +40,6 @@ The default \code{order="original"} returns unique values in the order of the fi
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\seealso{
-  \code{\link{unique}} for the generic, \code{\link{unipos}} which gives the indices of the unique
-  elements and \code{\link{table.integer64}} which gives frequencies of the unique elements.
-}
 \examples{
 x <- as.integer64(sample(c(rep(NA, 9), 1:9), 32, TRUE))
 unique(x)
@@ -53,6 +49,10 @@ stopifnot(identical(unique(x),  x[!duplicated(x)]))
 stopifnot(identical(unique(x),  as.integer64(unique(as.integer(x)))))
 stopifnot(identical(unique(x, order="values")
 ,  as.integer64(sort(unique(as.integer(x)), na.last=FALSE))))
+}
+\seealso{
+  \code{\link{unique}} for the generic, \code{\link{unipos}} which gives the indices of the unique
+  elements and \code{\link{table.integer64}} which gives frequencies of the unique elements.
 }
 \keyword{manip}
 \keyword{logic}

--- a/man/xor.integer64.Rd
+++ b/man/xor.integer64.Rd
@@ -73,9 +73,6 @@ binattr(e1,e2) # for internal use only
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
-\keyword{ classes }
-\keyword{ manip }
-\seealso{ \code{\link{format.integer64}} \code{\link{integer64}}  }
 \examples{
   as.integer64(1:12) - 1
   options(integer64_semantics="new")
@@ -89,3 +86,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   d*i  # old: 10
   i*d  # old: 13
 }
+\seealso{ \code{\link{format.integer64}} \code{\link{integer64}}  }
+\keyword{ classes }
+\keyword{ manip }

--- a/man/xor.integer64.Rd
+++ b/man/xor.integer64.Rd
@@ -19,9 +19,6 @@
 \title{
    Binary operators for integer64 vectors
 }
-\description{
-  Binary operators for integer64 vectors.
-}
 \usage{
 \method{&}{integer64}(e1,e2)
 
@@ -69,6 +66,9 @@ binattr(e1,e2) # for internal use only
   \code{\link{^}} and \code{\link{/}} return a double vector\cr
   \code{\link{+}}, \code{\link{-}}, \code{\link{*}}, \code{\link{\%/\%}}, \code{\link{\%\%}}
    return a vector of class 'integer64'
+}
+\description{
+  Binary operators for integer64 vectors.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>


### PR DESCRIPTION
Again towards shrinking the diff in #61 & making it easier to spot inconsistencies.

Didn't change anything in the R/ version, it's just busywork at this point I reckon

A programmatic approach:

```r
non_sections = c("item", "code", "emph", "itemize", "dontshow", "verb", "method", "subsection", "if", "strong", "tabular")
section_names = function(l) {
  l |>
    grep(pattern = "^[\\][a-zA-Z0-9_]+[{]", value=TRUE) |>
    gsub(pattern = "^[\\]|\\{.*", replacement = "") |>
    setdiff(non_sections)
}

section_ordering_in_branch = function(branch) {
  system2("git", c("checkout", branch))
  rd = Sys.glob("man/*.Rd")
  rdl = lapply(rd, readLines)
  names(rdl) = rd
  
  lapply(rdl, section_names)
}

old = section_ordering_in_branch("master")
new = section_ordering_in_branch("roxygen")

# all.equal() might be nice but there are other differences between the branches still
for (rd in names(new)) {
  o = old[[rd]]
  n = new[[rd]]
  old[[rd]] = o[o %in% n]
  new[[rd]] = n[n %in% o]
}

for (rd in names(new)) if (!isTRUE(all.equal(old[[rd]], new[[rd]]))) {
  message(rd)
  print(cbind(old[[rd]], new[[rd]]))
}
```