### PR TITLE
Combine arguments with the same description to one \item

### DIFF
--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -34,11 +34,7 @@
 
   \item{quote}{ logical, indicating whether or not strings should be printed with surrounding quotes. }
 
-  \item{vec.len}{ see \code{\link[utils]{str}} }
-
-  \item{give.head}{ see \code{\link[utils]{str}} }
-
-  \item{give.length}{ see \code{\link[utils]{str}} }
+  \item{vec.len, give.head, give.length}{ see \code{\link[utils]{str}} }
 
   \item{...}{ further arguments to the \code{\link{NextMethod}} }
 }

--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -37,11 +37,7 @@ remcache(x)
   An object to be stored in the cache
 }
 
-  \item{all.names}{
-  passed to \code{\link{ls}} when listing the cache content
-}
-
-  \item{pattern}{
+  \item{all.names, pattern}{
   passed to \code{\link{ls}} when listing the cache content
 }
 

--- a/man/hashmap.Rd
+++ b/man/hashmap.Rd
@@ -84,8 +84,6 @@ hashmaptab(x, ...)
 \arguments{
   \item{x}{ an integer64 vector }
 
-  \item{hashmap}{ an object of class 'hashmap' i.e. here 'cache_integer64' }
-
   \item{minfac}{ minimum factor by which the hasmap has more elements compared to the data \code{x}, ignored if \code{hashbits} is given directly }
 
   \item{hashbits}{ length of hashmap is \code{2^hashbits} }


### PR DESCRIPTION
This makes the _set_ of `\\item` values the same between `master` and #61. Next will be to put those arguments in the same _order_ too.

Code for analyzing the `\arguments{\item}` entries:

```r
library(tools)

args_on_branch = function(branch) {
  system(paste('git checkout', branch))
  rd = Sys.glob("man/*.Rd")
  args = lapply(rd, function(f) {
    arguments = Filter(\(x) attr(x, "Rd_tag") == "\\arguments", parse_Rd(f))
    if (!length(arguments)) return(NULL)
    sapply(Filter(\(x) attr(x, "Rd_tag") == "\\item", arguments[[1L]]), \(x) unlist(x[[1]]))
  })
  names(args) = rd
  args
}

old = args_on_branch('master')
new = args_on_branch('roxygen')
```