### PR TITLE
Revert "Use roxygen2-like style for simple links"

### DIFF
--- a/man/all.equal.integer64.Rd
+++ b/man/all.equal.integer64.Rd
@@ -16,9 +16,9 @@
 )
 }
 \arguments{
-  \item{target}{ a vector of 'integer64' or an object that can be coerced with code{link[=as.integer64]{as.integer64()}} }
+  \item{target}{ a vector of 'integer64' or an object that can be coerced with \code{\link{as.integer64}} }
 
-  \item{current}{ a vector of 'integer64' or an object that can be coerced with code{link[=as.integer64]{as.integer64()}} }
+  \item{current}{ a vector of 'integer64' or an object that can be coerced with \code{\link{as.integer64}} }
 
   \item{tolerance}{numeric \eqn{\ge} 0.  Differences smaller than
     \code{tolerance} are not reported.  The default value is close to
@@ -33,7 +33,7 @@
     misleading in cases where \code{target} and \code{current} only
     differ in a few places; see the extensive example.}
 
-  \item{formatFUN}{a code{link[=function]{function()}} of two arguments,
+  \item{formatFUN}{a \code{\link{function}} of two arguments,
     \code{err}, the relative, absolute or scaled error, and
     \code{what}, a character string indicating the \emph{kind} of error;
     maybe used, e.g., to format relative and absolute errors differently.}
@@ -41,7 +41,7 @@
   \item{...}{further arguments are ignored}
 
   \item{check.attributes}{logical indicating if the
-    code{link[=attributes]{attributes()}} of \code{target} and \code{current}
+    \code{\link{attributes}} of \code{target} and \code{current}
     (other than the names) should be compared.}
 }
 \value{
@@ -50,19 +50,19 @@
   ‘current’.
 }
 \description{
-   A utility to compare integer64 objects 'x' and 'y' testing for ‘near equality’, see code{link[=all.equal]{all.equal()}}.
+   A utility to compare integer64 objects 'x' and 'y' testing for ‘near equality’, see \code{\link{all.equal}}.
 }
 \details{
-   In code{link[=all.equal.numeric]{all.equal.numeric()}} the type \code{integer} is treated as a proper subset of \code{double}
+   In \code{\link{all.equal.numeric}} the type \code{integer} is treated as a proper subset of \code{double}
    i.e. does not complain about comparing \code{integer} with \code{double}.
    Following this logic \code{all.equal.integer64} treats \code{integer} as a proper subset of \code{integer64}
    and does not complain about comparing \code{integer} with \code{integer64}. \code{double} also compares without warning
-   as long as the values are within code{link[=lim.integer64]{lim.integer64()}}, if \code{double} are bigger \code{all.equal.integer64}
-   complains about the \code{all.equal.integer64 overflow warning}. For further details see code{link[=all.equal]{all.equal()}}.
+   as long as the values are within \code{\link{lim.integer64}}, if \code{double} are bigger \code{all.equal.integer64}
+   complains about the \code{all.equal.integer64 overflow warning}. For further details see \code{\link{all.equal}}.
 }
 \note{
-   code{link[=all.equal]{all.equal()}} only dispatches to this method if the first argument is \code{integer64},
-   calling code{link[=all.equal]{all.equal()}} with a \code{non-integer64} first and a \code{integer64} second argument
+   \code{\link{all.equal}} only dispatches to this method if the first argument is \code{integer64},
+   calling \code{\link{all.equal}} with a \code{non-integer64} first and a \code{integer64} second argument
    gives undefined behavior!
 }
 \author{
@@ -75,5 +75,5 @@
   all.equal(as.integer64(1), as.double(1e300))
 }
 \seealso{
-  code{link[=all.equal]{all.equal()}}
+  \code{\link{all.equal}}
 }

--- a/man/as.character.integer64.Rd
+++ b/man/as.character.integer64.Rd
@@ -30,7 +30,7 @@
 \arguments{
   \item{x}{ an integer64 vector }
 
-  \item{...}{ further arguments to the code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ further arguments to the \code{\link{NextMethod}} }
 
   \item{keep.names}{ FALSE, set to TRUE to keep a names vector }
 }
@@ -41,8 +41,8 @@
 \description{
   Methods to coerce integer64 to other atomic types.
   'as.bitstring' coerces to a human-readable bit representation (strings of zeroes and ones).
-  The methods code{link[=format]{format()}}, \code{\link{as.character}}, code{link[=as.double]{as.double()}},
-  code{link[=as.logical]{as.logical()}}, \code{\link{as.integer}} do what you would expect.
+  The methods \code{\link{format}}, \code{\link{as.character}}, \code{\link{as.double}},
+  \code{\link{as.logical}}, \code{\link{as.integer}} do what you would expect.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
@@ -54,6 +54,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
    -2,-1,NA,0:2
   )))
 }
-\seealso{ code{link[=as.integer64.character]{as.integer64.character()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{as.integer64.character}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/as.data.frame.integer64.Rd
+++ b/man/as.data.frame.integer64.Rd
@@ -9,7 +9,7 @@
 \arguments{
   \item{x}{ an integer64 vector }
 
-  \item{...}{ passed to NextMethod code{link[=as.data.frame]{as.data.frame()}} after removing the 'integer64' class attribute }
+  \item{...}{ passed to NextMethod \code{\link{as.data.frame}} after removing the 'integer64' class attribute }
 }
 \value{
   a one-column data.frame containing an integer64 vector
@@ -32,7 +32,7 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   data.frame(a=1:12, b=as.integer64(1:12))
 }
 \seealso{
-  code{link[=cbind.integer64]{cbind.integer64()}} \code{\link{integer64}}  %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}}
+  \code{\link{cbind.integer64}} \code{\link{integer64}}  %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}}
 }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/as.integer64.character.Rd
+++ b/man/as.integer64.character.Rd
@@ -36,7 +36,7 @@
 \arguments{
   \item{x}{ an atomic vector }
 
-  \item{...}{ further arguments to the code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ further arguments to the \code{\link{NextMethod}} }
 
   \item{keep.names}{ FALSE, set to TRUE to keep a names vector }
 }
@@ -79,6 +79,6 @@ as.integer64(
   ), class = "bitstring")
 )
 }
-\seealso{ code{link[=as.character.integer64]{as.character.integer64()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{as.character.integer64}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/benchmark64.Rd
+++ b/man/benchmark64.Rd
@@ -21,18 +21,18 @@ optimizer64(nsmall = 2^16, nbig = 2^25, timefun = repeat.time
 
   \item{nbig}{ size of larger bigger vector }
 
-  \item{timefun}{ a function for timing such as \code{\link[bit]{repeat.time}} or code{link[=system.time]{system.time()}} }
+  \item{timefun}{ a function for timing such as \code{\link[bit]{repeat.time}} or \code{\link{system.time}} }
 
   \item{what}{
  a vector of names of high-level functions
 }
 
   \item{uniorder}{
- one of the order parameters that are allowed in code{link[=unique.integer64]{unique.integer64()}} and code{link[=unipos.integer64]{unipos.integer64()}}
+ one of the order parameters that are allowed in \code{\link{unique.integer64}} and \code{\link{unipos.integer64}}
 }
 
   \item{taborder}{
- one of the order parameters that are allowed in code{link[=table.integer64]{table.integer64()}}
+ one of the order parameters that are allowed in \code{\link{table.integer64}}
 }
 
   \item{plot}{
@@ -54,9 +54,9 @@ optimizer64(nsmall = 2^16, nbig = 2^25, timefun = repeat.time
   \bold{scenario name} \tab \bold{explanation} \cr
   32-bit  \tab applying Base R function to 32-bit integer data \cr
   64-bit \tab applying bit64 function to 64-bit integer data (with no cache) \cr
-  hashcache \tab dito when cache contains code{link[=hashmap]{hashmap()}}, see code{link[=hashcache]{hashcache()}} \cr
-  sortordercache \tab dito when cache contains sorting and ordering, see code{link[=sortordercache]{sortordercache()}} \cr
-  ordercache \tab dito when cache contains ordering only, see code{link[=ordercache]{ordercache()}} \cr
+  hashcache \tab dito when cache contains \code{\link{hashmap}}, see \code{\link{hashcache}} \cr
+  sortordercache \tab dito when cache contains sorting and ordering, see \code{\link{sortordercache}} \cr
+  ordercache \tab dito when cache contains ordering only, see \code{\link{ordercache}} \cr
   allcache \tab dito when cache contains sorting, ordering and hashing \cr
  }
  \tabular{rl}{

--- a/man/benchmark64.data.Rd
+++ b/man/benchmark64.data.Rd
@@ -13,7 +13,7 @@
 }
 \usage{data(benchmark64.data)}
 \description{
-  These are the results of calling code{link[=benchmark64]{benchmark64()}}
+  These are the results of calling \code{\link{benchmark64}}
 }
 \examples{
 data(benchmark64.data)

--- a/man/bit64-package.Rd
+++ b/man/bit64-package.Rd
@@ -24,7 +24,7 @@
  \method{str}{integer64}(object, vec.len  = strO$vec.len, give.head = TRUE, give.length = give.head, ...)
 }
 \arguments{
-  \item{length}{ length of vector using code{link[=integer]{integer()}} }
+  \item{length}{ length of vector using \code{\link{integer}} }
 
   \item{x}{ an integer64 vector }
 
@@ -32,7 +32,7 @@
 
   \item{quote}{ logical, indicating whether or not strings should be printed with surrounding quotes. }
 
-  \item{...}{ further arguments to the code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ further arguments to the \code{\link{NextMethod}} }
 
   \item{object}{ an integer64 vector }
 
@@ -40,7 +40,7 @@
 }
 \value{
   \code{integer64} returns a vector of 'integer64',
-   i.e. a vector of code{link[=double]{double()}} decorated with class 'integer64'.
+   i.e. a vector of \code{\link{double}} decorated with class 'integer64'.
 }
 \description{
 Package 'bit64' provides fast serializable S3 atomic 64bit (signed) integers
@@ -120,8 +120,8 @@ is not worth it with 32x at duplicated RAM consumption).
   Like the other atomic types in Base R, we model data type 'integer64' as a contiguous \code{\link{atomic}} vector in memory,
   and we use the more basic \code{\link{S3}} class system, not \code{\link{S4}}. Like package \code{int64} we want our 'integer64' to be \code{\link{serialize}able},
   therefore we also use an existing data type as the basis. Again the choice is obvious: R has only one 64 bit data type: doubles.
-  By using \code{\link{double}s}, \code{integer64} \code{\link{inherits}} some functionality such as code{link[=is.atomic]{is.atomic()}}, code{link[=length]{length()}},
-  \code{\link{length<-}}, code{link[=names]{names()}}, \code{\link{names<-}}, code{link[=dim]{dim()}}, \code{\link{dim<-}}, code{link[=dimnames]{dimnames()}}, code{link[=dimnames]{dimnames()}}.
+  By using \code{\link{double}s}, \code{integer64} \code{\link{inherits}} some functionality such as \code{\link{is.atomic}}, \code{\link{length}},
+  \code{\link{length<-}}, \code{\link{names}}, \code{\link{names<-}}, \code{\link{dim}}, \code{\link{dim<-}}, \code{\link{dimnames}}, \code{\link{dimnames}}.
   \cr
   Our R level functions strictly follow the functional programming paragdim:
   no modification of arguments or other side-effects. Before version 0.93  we internally deviated from the strict paradigm
@@ -131,11 +131,11 @@ is not worth it with 32x at duplicated RAM consumption).
   Prior to 0.93 \emph{within} our R functions we also deviated from conventional R programming by not using \code{\link{attr<-}} and \code{\link{attributes<-}}
   because they always did new memory allocation and copying in older R versions. If we wanted to set attributes of return values that we have freshly created,
   we instead used functions \code{\link[bit:getsetattr]{setattr}} and \code{\link[bit:getsetattr]{setattributes}} from package \code{\link[bit]{bit}}.
-  From version 0.93 \code{\link[bit:getsetattr]{setattr}} is only used for manipulating code{link[=cache]{cache()}} objects, in code{link[=ramsort.integer64]{ramsort.integer64()}} and code{link[=sort.integer64]{sort.integer64()}} and in code{link[=as.data.frame.integer64]{as.data.frame.integer64()}}.
+  From version 0.93 \code{\link[bit:getsetattr]{setattr}} is only used for manipulating \code{\link{cache}} objects, in \code{\link{ramsort.integer64}} and \code{\link{sort.integer64}} and in \code{\link{as.data.frame.integer64}}.
 }
 \section{Arithmetic precision and coercion}{
   The fact that we introduce 64 bit long long integers -- without introducing 128-bit long doubles -- creates some subtle challenges:
-  Unlike 32 bit \code{\link{integer}s}, the \code{integer64} are no longer a proper subset of code{link[=double]{double()}}.
+  Unlike 32 bit \code{\link{integer}s}, the \code{integer64} are no longer a proper subset of \code{\link{double}}.
   If a binary arithmetic operation does involve a \code{double} and a \code{integer}, it is a no-brainer to return \code{double}
   without loss of information. If an \code{integer64} meets a \code{double}, it is not trivial what type to return.
   Switching to \code{integer64} limits our ability to represent very large numbers, switching to \code{double} limits our ability
@@ -178,13 +178,13 @@ is not worth it with 32x at duplicated RAM consumption).
   attaches an S3 class attribute 'integer64' to it, and that's it. We simply rely on S3 method dispatch and interpret those
   64bit elements as 'long long int'.
   \cr
- code{link[=is.double]{is.double()}} currently returns TRUE for \code{integer64} and might return FALSE in a later release.
+ \code{\link{is.double}} currently returns TRUE for \code{integer64} and might return FALSE in a later release.
  Consider \code{is.double} to have undefined behavior and do query \code{is.integer64} \emph{before} querying \code{is.double}.
-%As a second line of defense against misinterpretation we make code{link[=is.double]{is.double()}}
-%return \code{FALSE} by making it S3 generic and adding a method code{link[=as.double.integer64]{as.double.integer64()}}.
-  The methods code{link[=is.integer64]{is.integer64()}} and code{link[=is.vector]{is.vector()}} both return \code{TRUE} for \code{integer64}.
- Note that we did not patch code{link[=storage.mode]{storage.mode()}} and \code{\link{typeof}}, which both continue returning 'double'
- Like for 32 bit code{link[=integer]{integer()}}, code{link[=mode]{mode()}} returns 'numeric' and code{link[=as.double]{as.double()}}) tries coercing to code{link[=double]{double()}}).
+%As a second line of defense against misinterpretation we make \code{\link{is.double}}
+%return \code{FALSE} by making it S3 generic and adding a method \code{\link{as.double.integer64}}.
+  The methods \code{\link{is.integer64}} and \code{\link{is.vector}} both return \code{TRUE} for \code{integer64}.
+ Note that we did not patch \code{\link{storage.mode}} and \code{\link{typeof}}, which both continue returning 'double'
+ Like for 32 bit \code{\link{integer}}, \code{\link{mode}} returns 'numeric' and \code{\link{as.double}}) tries coercing to \code{\link{double}}).
  It is possible that 'integer64' becomes a \code{vmode} in package \code{ff}.
  \cr
  Further methods for creating \code{integer64} are \code{\link[=range.integer64]{range}} which returns the range of the data type if calles without arguments,
@@ -196,53 +196,53 @@ is not worth it with 32x at duplicated RAM consumption).
 \tabular{rrl}{
    \bold{creating,testing,printing} \tab \bold{see also}          \tab \bold{description} \cr
    \code{NA_integer64_} \tab \code{\link{NA_integer_}} \tab NA constant \cr
-   \code{integer64} \tab code{link[=integer]{integer()}} \tab create zero atomic vector \cr
-   code{link[=runif64]{runif64()}} \tab code{link[=runif]{runif()}} \tab create random vector \cr
-   code{link[=rep.integer64]{rep.integer64()}} \tab code{link[=rep]{rep()}} \tab  \cr
-   code{link[=seq.integer64]{seq.integer64()}} \tab code{link[=seq]{seq()}} \tab  \cr
-   code{link[=is.integer64]{is.integer64()}} \tab \code{\link{is}} \tab  \cr
-                                     \tab code{link[=is.integer]{is.integer()}} \tab inherited from Base R \cr
-   %\code{\link{is.double.integer64}} \tab code{link[=is.double]{is.double()}} \tab  \cr
-   code{link[=is.vector.integer64]{is.vector.integer64()}} \tab code{link[=is.vector]{is.vector()}} \tab  \cr
-   code{link[=identical.integer64]{identical.integer64()}} \tab code{link[=identical]{identical()}} \tab  \cr
+   \code{integer64} \tab \code{\link{integer}} \tab create zero atomic vector \cr
+   \code{\link{runif64}} \tab \code{\link{runif}} \tab create random vector \cr
+   \code{\link{rep.integer64}} \tab \code{\link{rep}} \tab  \cr
+   \code{\link{seq.integer64}} \tab \code{\link{seq}} \tab  \cr
+   \code{\link{is.integer64}} \tab \code{\link{is}} \tab  \cr
+                                     \tab \code{\link{is.integer}} \tab inherited from Base R \cr
+   %\code{\link{is.double.integer64}} \tab \code{\link{is.double}} \tab  \cr
+   \code{\link{is.vector.integer64}} \tab \code{\link{is.vector}} \tab  \cr
+   \code{\link{identical.integer64}} \tab \code{\link{identical}} \tab  \cr
    \code{\link{length<-.integer64}} \tab \code{\link{length<-}} \tab  \cr
-                                     \tab code{link[=length]{length()}} \tab inherited from Base R \cr
+                                     \tab \code{\link{length}} \tab inherited from Base R \cr
                                      \tab \code{\link{names<-}} \tab inherited from Base R \cr
-                                     \tab code{link[=names]{names()}} \tab inherited from Base R \cr
+                                     \tab \code{\link{names}} \tab inherited from Base R \cr
                                      \tab \code{\link{dim<-}} \tab inherited from Base R \cr
-                                     \tab code{link[=dim]{dim()}} \tab inherited from Base R \cr
+                                     \tab \code{\link{dim}} \tab inherited from Base R \cr
                                      \tab \code{\link{dimnames<-}} \tab inherited from Base R \cr
-                                     \tab code{link[=dimnames]{dimnames()}} \tab inherited from Base R \cr
-                                    \tab code{link[=str]{str()}} \tab inherited from Base R, does not print values correctly \cr
-   code{link[=print.integer64]{print.integer64()}} \tab \code{\link{print}} \tab  \cr
-   code{link[=str.integer64]{str.integer64()}} \tab code{link[=str]{str()}} \tab  \cr
+                                     \tab \code{\link{dimnames}} \tab inherited from Base R \cr
+                                    \tab \code{\link{str}} \tab inherited from Base R, does not print values correctly \cr
+   \code{\link{print.integer64}} \tab \code{\link{print}} \tab  \cr
+   \code{\link{str.integer64}} \tab \code{\link{str}} \tab  \cr
  \cr
    \bold{coercing to integer64} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=as.integer64]{as.integer64()}} \tab   \tab generic \cr
-   code{link[=as.integer64.bitstring]{as.integer64.bitstring()}} \tab code{link[=as.bitstring]{as.bitstring()}} \tab  \cr
-   code{link[=as.integer64.character]{as.integer64.character()}} \tab \code{\link{character}} \tab  \cr
-   code{link[=as.integer64.double]{as.integer64.double()}} \tab code{link[=double]{double()}} \tab  \cr
-   code{link[=as.integer64.integer]{as.integer64.integer()}} \tab code{link[=integer]{integer()}} \tab  \cr
-   code{link[=as.integer64.integer64]{as.integer64.integer64()}} \tab \code{integer64} \tab  \cr
-   code{link[=as.integer64.logical]{as.integer64.logical()}} \tab \code{\link{logical}} \tab  \cr
-   code{link[=as.integer64.NULL]{as.integer64.NULL()}} \tab \code{\link{NULL}} \tab  \cr
+   \code{\link{as.integer64}} \tab   \tab generic \cr
+   \code{\link{as.integer64.bitstring}} \tab \code{\link{as.bitstring}} \tab  \cr
+   \code{\link{as.integer64.character}} \tab \code{\link{character}} \tab  \cr
+   \code{\link{as.integer64.double}} \tab \code{\link{double}} \tab  \cr
+   \code{\link{as.integer64.integer}} \tab \code{\link{integer}} \tab  \cr
+   \code{\link{as.integer64.integer64}} \tab \code{integer64} \tab  \cr
+   \code{\link{as.integer64.logical}} \tab \code{\link{logical}} \tab  \cr
+   \code{\link{as.integer64.NULL}} \tab \code{\link{NULL}} \tab  \cr
  \cr
    \bold{coercing from integer64} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=as.list.integer64]{as.list.integer64()}} \tab \code{\link{as.list}} \tab generic \cr
-   code{link[=as.bitstring]{as.bitstring()}} \tab code{link[=as.bitstring]{as.bitstring()}} \tab generic \cr
-   code{link[=as.bitstring.integer64]{as.bitstring.integer64()}} \tab  \tab  \cr
-   code{link[=as.character.integer64]{as.character.integer64()}} \tab \code{\link{as.character}} \tab  \cr
-   code{link[=as.double.integer64]{as.double.integer64()}} \tab code{link[=as.double]{as.double()}} \tab  \cr
-   code{link[=as.integer.integer64]{as.integer.integer64()}} \tab \code{\link{as.integer}} \tab  \cr
-   code{link[=as.logical.integer64]{as.logical.integer64()}} \tab code{link[=as.logical]{as.logical()}} \tab  \cr
-   %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}} \tab code{link[=as.vector]{as.vector()}} \tab  \cr
+   \code{\link{as.list.integer64}} \tab \code{\link{as.list}} \tab generic \cr
+   \code{\link{as.bitstring}} \tab \code{\link{as.bitstring}} \tab generic \cr
+   \code{\link{as.bitstring.integer64}} \tab  \tab  \cr
+   \code{\link{as.character.integer64}} \tab \code{\link{as.character}} \tab  \cr
+   \code{\link{as.double.integer64}} \tab \code{\link{as.double}} \tab  \cr
+   \code{\link{as.integer.integer64}} \tab \code{\link{as.integer}} \tab  \cr
+   \code{\link{as.logical.integer64}} \tab \code{\link{as.logical}} \tab  \cr
+   %as.vector.integer64 removed as requested by the CRAN maintainer \code{\link{as.vector.integer64}} \tab \code{\link{as.vector}} \tab  \cr
  \cr
    \bold{data structures} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=c.integer64]{c.integer64()}} \tab code{link[=c]{c()}} \tab vector concatenate \cr
-   code{link[=cbind.integer64]{cbind.integer64()}} \tab code{link[=cbind]{cbind()}} \tab column bind \cr
-   code{link[=rbind.integer64]{rbind.integer64()}} \tab \code{\link{rbind}} \tab row bind \cr
-   code{link[=as.data.frame.integer64]{as.data.frame.integer64()}} \tab code{link[=as.data.frame]{as.data.frame()}} \tab coerce atomic object to data.frame \cr
-                                         \tab code{link[=data.frame]{data.frame()}} \tab inherited from Base R since we have coercion \cr
+   \code{\link{c.integer64}} \tab \code{\link{c}} \tab vector concatenate \cr
+   \code{\link{cbind.integer64}} \tab \code{\link{cbind}} \tab column bind \cr
+   \code{\link{rbind.integer64}} \tab \code{\link{rbind}} \tab row bind \cr
+   \code{\link{as.data.frame.integer64}} \tab \code{\link{as.data.frame}} \tab coerce atomic object to data.frame \cr
+                                         \tab \code{\link{data.frame}} \tab inherited from Base R since we have coercion \cr
  \cr
    \bold{subscripting} \tab \bold{see also}          \tab \bold{description} \cr
    \code{\link{[.integer64}} \tab \code{\link{[}} \tab vector and array extract \cr
@@ -271,71 +271,71 @@ is not worth it with 32x at duplicated RAM consumption).
    \code{\link{!.integer64}} \tab \code{\link{!}} \tab  \cr
    \code{\link{&.integer64}} \tab \code{\link{&}} \tab  \cr
    \code{\link{|.integer64}} \tab \code{\link{|}} \tab  \cr
-   code{link[=xor.integer64]{xor.integer64()}} \tab code{link[=xor]{xor()}} \tab  \cr
+   \code{\link{xor.integer64}} \tab \code{\link{xor}} \tab  \cr
  \cr
    \bold{math functions} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=is.na.integer64]{is.na.integer64()}} \tab code{link[=is.na]{is.na()}} \tab returns logical \cr
-   code{link[=format.integer64]{format.integer64()}} \tab code{link[=format]{format()}} \tab returns character \cr
-   code{link[=abs.integer64]{abs.integer64()}} \tab \code{\link{abs}} \tab returns integer64 \cr
-   code{link[=sign.integer64]{sign.integer64()}} \tab code{link[=sign]{sign()}} \tab returns integer64 \cr
-   code{link[=log.integer64]{log.integer64()}} \tab \code{\link{log}} \tab returns double \cr
-   code{link[=log10.integer64]{log10.integer64()}} \tab \code{\link{log10}} \tab  returns double \cr
-   code{link[=log2.integer64]{log2.integer64()}} \tab \code{\link{log2}} \tab  returns double \cr
-   code{link[=sqrt.integer64]{sqrt.integer64()}} \tab code{link[=sqrt]{sqrt()}} \tab  returns double \cr
-   code{link[=ceiling.integer64]{ceiling.integer64()}} \tab \code{\link{ceiling}} \tab dummy returning its argument \cr
-   code{link[=floor.integer64]{floor.integer64()}} \tab \code{\link{floor}} \tab dummy returning its argument \cr
-   code{link[=trunc.integer64]{trunc.integer64()}} \tab \code{\link{trunc}} \tab dummy returning its argument \cr
-   code{link[=round.integer64]{round.integer64()}} \tab code{link[=round]{round()}} \tab dummy returning its argument \cr
-   code{link[=signif.integer64]{signif.integer64()}} \tab code{link[=signif]{signif()}} \tab dummy returning its argument \cr
+   \code{\link{is.na.integer64}} \tab \code{\link{is.na}} \tab returns logical \cr
+   \code{\link{format.integer64}} \tab \code{\link{format}} \tab returns character \cr
+   \code{\link{abs.integer64}} \tab \code{\link{abs}} \tab returns integer64 \cr
+   \code{\link{sign.integer64}} \tab \code{\link{sign}} \tab returns integer64 \cr
+   \code{\link{log.integer64}} \tab \code{\link{log}} \tab returns double \cr
+   \code{\link{log10.integer64}} \tab \code{\link{log10}} \tab  returns double \cr
+   \code{\link{log2.integer64}} \tab \code{\link{log2}} \tab  returns double \cr
+   \code{\link{sqrt.integer64}} \tab \code{\link{sqrt}} \tab  returns double \cr
+   \code{\link{ceiling.integer64}} \tab \code{\link{ceiling}} \tab dummy returning its argument \cr
+   \code{\link{floor.integer64}} \tab \code{\link{floor}} \tab dummy returning its argument \cr
+   \code{\link{trunc.integer64}} \tab \code{\link{trunc}} \tab dummy returning its argument \cr
+   \code{\link{round.integer64}} \tab \code{\link{round}} \tab dummy returning its argument \cr
+   \code{\link{signif.integer64}} \tab \code{\link{signif}} \tab dummy returning its argument \cr
  \cr
    \bold{cumulative functions} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=cummin.integer64]{cummin.integer64()}} \tab code{link[=cummin]{cummin()}} \tab \cr
-   code{link[=cummax.integer64]{cummax.integer64()}} \tab \code{\link{cummax}} \tab \cr
-   code{link[=cumsum.integer64]{cumsum.integer64()}} \tab \code{\link{cumsum}} \tab \cr
-   code{link[=cumprod.integer64]{cumprod.integer64()}} \tab \code{\link{cumprod}} \tab \cr
-   code{link[=diff.integer64]{diff.integer64()}} \tab code{link[=diff]{diff()}} \tab \cr
+   \code{\link{cummin.integer64}} \tab \code{\link{cummin}} \tab \cr
+   \code{\link{cummax.integer64}} \tab \code{\link{cummax}} \tab \cr
+   \code{\link{cumsum.integer64}} \tab \code{\link{cumsum}} \tab \cr
+   \code{\link{cumprod.integer64}} \tab \code{\link{cumprod}} \tab \cr
+   \code{\link{diff.integer64}} \tab \code{\link{diff}} \tab \cr
  \cr
    \bold{summary functions} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=range.integer64]{range.integer64()}} \tab code{link[=range]{range()}} \tab \cr
-   code{link[=min.integer64]{min.integer64()}} \tab code{link[=min]{min()}} \tab  \cr
-   code{link[=max.integer64]{max.integer64()}} \tab \code{\link{max}} \tab  \cr
-   code{link[=sum.integer64]{sum.integer64()}} \tab \code{\link{sum}} \tab  \cr
-   code{link[=mean.integer64]{mean.integer64()}} \tab \code{\link{mean}} \tab  \cr
-   code{link[=prod.integer64]{prod.integer64()}} \tab \code{\link{prod}} \tab  \cr
-   code{link[=all.integer64]{all.integer64()}} \tab code{link[=all]{all()}} \tab  \cr
-   code{link[=any.integer64]{any.integer64()}} \tab \code{\link{any}} \tab  \cr
+   \code{\link{range.integer64}} \tab \code{\link{range}} \tab \cr
+   \code{\link{min.integer64}} \tab \code{\link{min}} \tab  \cr
+   \code{\link{max.integer64}} \tab \code{\link{max}} \tab  \cr
+   \code{\link{sum.integer64}} \tab \code{\link{sum}} \tab  \cr
+   \code{\link{mean.integer64}} \tab \code{\link{mean}} \tab  \cr
+   \code{\link{prod.integer64}} \tab \code{\link{prod}} \tab  \cr
+   \code{\link{all.integer64}} \tab \code{\link{all}} \tab  \cr
+   \code{\link{any.integer64}} \tab \code{\link{any}} \tab  \cr
  \cr
    \bold{algorithmically complex functions} \tab \bold{see also}          \tab \bold{description (caching)}  \cr
-   code{link[=match.integer64]{match.integer64()}} \tab code{link[=match]{match()}} \tab position of x in table (h//o/so) \cr
+   \code{\link{match.integer64}} \tab \code{\link{match}} \tab position of x in table (h//o/so) \cr
    \code{\link{\%in\%.integer64}} \tab \code{\link{\%in\%}} \tab is x in table? (h//o/so) \cr
-   code{link[=duplicated.integer64]{duplicated.integer64()}} \tab code{link[=duplicated]{duplicated()}} \tab is current element duplicate of previous one? (h//o/so) \cr
-   code{link[=unique.integer64]{unique.integer64()}} \tab code{link[=unique]{unique()}} \tab (shorter) vector of unique values only (h/s/o/so) \cr
-   code{link[=unipos.integer64]{unipos.integer64()}} \tab \code{\link{unipos}} \tab positions corresponding to unique values (h/s/o/so) \cr
-   code{link[=tiepos.integer64]{tiepos.integer64()}} \tab \code{\link{tiepos}} \tab positions of values that are tied (//o/so) \cr
-   code{link[=keypos.integer64]{keypos.integer64()}} \tab code{link[=keypos]{keypos()}} \tab position of current value in sorted list of unique values (//o/so) \cr
-   code{link[=table.integer64]{table.integer64()}} \tab code{link[=table]{table()}} \tab unique values and their frequencies (h/s/o/so) \cr
-   code{link[=sort.integer64]{sort.integer64()}} \tab code{link[=sort]{sort()}} \tab sorted vector (/s/o/so) \cr
-   code{link[=order.integer64]{order.integer64()}} \tab code{link[=order]{order()}} \tab positions of elements that would create sorted vector (//o/so) \cr
-   code{link[=rank.integer64]{rank.integer64()}} \tab code{link[=rank]{rank()}} \tab (average) ranks of non-NAs, NAs kept in place (/s/o/so) \cr
-   code{link[=quantile.integer64]{quantile.integer64()}} \tab \code{\link{quantile}} \tab (existing) values at specified percentiles (/s/o/so) \cr
-   code{link[=median.integer64]{median.integer64()}} \tab \code{\link{median}} \tab (existing) value at percentile 0.5 (/s/o/so) \cr
-   code{link[=summary.integer64]{summary.integer64()}} \tab \code{\link{summary}} \tab  (/s/o/so) \cr
-   code{link[=all.equal.integer64]{all.equal.integer64()}} \tab code{link[=all.equal]{all.equal()}} \tab test if two objects are (nearly) equal (/s/o/so) \cr
+   \code{\link{duplicated.integer64}} \tab \code{\link{duplicated}} \tab is current element duplicate of previous one? (h//o/so) \cr
+   \code{\link{unique.integer64}} \tab \code{\link{unique}} \tab (shorter) vector of unique values only (h/s/o/so) \cr
+   \code{\link{unipos.integer64}} \tab \code{\link{unipos}} \tab positions corresponding to unique values (h/s/o/so) \cr
+   \code{\link{tiepos.integer64}} \tab \code{\link{tiepos}} \tab positions of values that are tied (//o/so) \cr
+   \code{\link{keypos.integer64}} \tab \code{\link{keypos}} \tab position of current value in sorted list of unique values (//o/so) \cr
+   \code{\link{table.integer64}} \tab \code{\link{table}} \tab unique values and their frequencies (h/s/o/so) \cr
+   \code{\link{sort.integer64}} \tab \code{\link{sort}} \tab sorted vector (/s/o/so) \cr
+   \code{\link{order.integer64}} \tab \code{\link{order}} \tab positions of elements that would create sorted vector (//o/so) \cr
+   \code{\link{rank.integer64}} \tab \code{\link{rank}} \tab (average) ranks of non-NAs, NAs kept in place (/s/o/so) \cr
+   \code{\link{quantile.integer64}} \tab \code{\link{quantile}} \tab (existing) values at specified percentiles (/s/o/so) \cr
+   \code{\link{median.integer64}} \tab \code{\link{median}} \tab (existing) value at percentile 0.5 (/s/o/so) \cr
+   \code{\link{summary.integer64}} \tab \code{\link{summary}} \tab  (/s/o/so) \cr
+   \code{\link{all.equal.integer64}} \tab \code{\link{all.equal}} \tab test if two objects are (nearly) equal (/s/o/so) \cr
  \cr
    \bold{helper functions} \tab \bold{see also}          \tab \bold{description} \cr
-   code{link[=minusclass]{minusclass()}} \tab code{link[=minusclass]{minusclass()}} \tab removing class attritbute \cr
-   code{link[=plusclass]{plusclass()}} \tab code{link[=plusclass]{plusclass()}} \tab inserting class attribute \cr
-   code{link[=binattr]{binattr()}} \tab code{link[=binattr]{binattr()}} \tab define binary op behaviour \cr
+   \code{\link{minusclass}} \tab \code{\link{minusclass}} \tab removing class attritbute \cr
+   \code{\link{plusclass}} \tab \code{\link{plusclass}} \tab inserting class attribute \cr
+   \code{\link{binattr}} \tab \code{\link{binattr}} \tab define binary op behaviour \cr
  \cr
    \bold{tested I/O functions} \tab \bold{see also}          \tab \bold{description} \cr
-                               \tab code{link[=read.table]{read.table()}} \tab inherited from Base R \cr
-                               \tab code{link[=write.table]{write.table()}} \tab inherited from Base R \cr
-                               \tab code{link[=serialize]{serialize()}} \tab inherited from Base R \cr
-                               \tab code{link[=unserialize]{unserialize()}} \tab inherited from Base R \cr
-                               \tab code{link[=save]{save()}} \tab inherited from Base R \cr
-                               \tab code{link[=load]{load()}} \tab inherited from Base R \cr
-                               \tab code{link[=dput]{dput()}} \tab inherited from Base R \cr
-                               \tab code{link[=dget]{dget()}} \tab inherited from Base R \cr
+                               \tab \code{\link{read.table}} \tab inherited from Base R \cr
+                               \tab \code{\link{write.table}} \tab inherited from Base R \cr
+                               \tab \code{\link{serialize}} \tab inherited from Base R \cr
+                               \tab \code{\link{unserialize}} \tab inherited from Base R \cr
+                               \tab \code{\link{save}} \tab inherited from Base R \cr
+                               \tab \code{\link{load}} \tab inherited from Base R \cr
+                               \tab \code{\link{dput}} \tab inherited from Base R \cr
+                               \tab \code{\link{dget}} \tab inherited from Base R \cr
 }
 }
 \section{Limitations inherited from implementing 64 bit integers via an external package}{
@@ -358,9 +358,9 @@ is not worth it with 32x at duplicated RAM consumption).
 }
 \section{Limitations inherited from Base R, Core team, can you change this?}{
   \itemize{
-    \item \bold{code{link[=identical]{identical()}}} with default parameters does not distinguish all bit-patterns of doubles.
-    For testing purposes we provide a wrapper code{link[=identical.integer64]{identical.integer64()}} that will distinguish all bit-patterns.
-    It would be desireable to have a single call of code{link[=identical]{identical()}} handle both, code{link[=double]{double()}} and \code{integer64}.
+    \item \bold{\code{\link{identical}}} with default parameters does not distinguish all bit-patterns of doubles.
+    For testing purposes we provide a wrapper \code{\link{identical.integer64}} that will distinguish all bit-patterns.
+    It would be desireable to have a single call of \code{\link{identical}} handle both, \code{\link{double}} and \code{integer64}.
 
     \item the \bold{colon} operator \code{\link{:}} officially does not dispatches S3 methods, however, we have made it generic
      \preformatted{
@@ -370,10 +370,10 @@ is not worth it with 32x at duplicated RAM consumption).
    }
    As a limitation remains: it will only dispatch at its first argument \code{from} but not at its second \code{to}.
 
-    \item \bold{code{link[=is.double]{is.double()}}} does not dispatches S3 methods, However, we have made it generic
+    \item \bold{\code{\link{is.double}}} does not dispatches S3 methods, However, we have made it generic
         and it will return \code{FALSE} on \code{integer64}.
 
-    \item \bold{code{link[=c]{c()}}} only dispatches code{link[=c.integer64]{c.integer64()}} if the first argument is \code{integer64}
+    \item \bold{\code{\link{c}}} only dispatches \code{\link{c.integer64}} if the first argument is \code{integer64}
     and it does not recursively dispatch the proper method when called with argument \code{recursive=TRUE}
     Therefore \preformatted{
       c(list(integer64,integer64))
@@ -394,27 +394,27 @@ is not worth it with 32x at duplicated RAM consumption).
     at least within their contributed classes. But as long as none of the package authors
     methods is dispatched, he cannot handle the conflicting classes at all.
 
-    \item \bold{code{link[=unlist]{unlist()}}} is not generic and if it were, we would face similar problems as with \code{c()}
+    \item \bold{\code{\link{unlist}}} is not generic and if it were, we would face similar problems as with \code{c()}
 
-    \item \bold{code{link[=vector]{vector()}}} with argument \code{mode='integer64'} cannot work without adjustment of Base R
-    \item \bold{code{link[=as.vector]{as.vector()}}} with argument \code{mode='integer64'} cannot work without adjustment of Base R
+    \item \bold{\code{\link{vector}}} with argument \code{mode='integer64'} cannot work without adjustment of Base R
+    \item \bold{\code{\link{as.vector}}} with argument \code{mode='integer64'} cannot work without adjustment of Base R
 
-    \item \bold{code{link[=is.vector]{is.vector()}}} does not dispatch its method code{link[=is.vector.integer64]{is.vector.integer64()}}
+    \item \bold{\code{\link{is.vector}}} does not dispatch its method \code{\link{is.vector.integer64}}
 
-    \item \bold{code{link[=mode<-]{mode<-()}}} drops the class 'integer64' which is returned from \code{as.integer64}.
+    \item \bold{\code{\link{mode<-}}} drops the class 'integer64' which is returned from \code{as.integer64}.
        Also it does not remove an existing class 'integer64' when assigning mode 'integer'.
 
-    \item \bold{code{link[=storage.mode<-]{storage.mode<-()}}} does not support external data types such as \code{as.integer64}
+    \item \bold{\code{\link{storage.mode<-}}} does not support external data types such as \code{as.integer64}
 
-    \item \bold{code{link[=matrix]{matrix()}}} does drop the 'integer64' class attribute.
+    \item \bold{\code{\link{matrix}}} does drop the 'integer64' class attribute.
 
-    \item \bold{code{link[=array]{array()}}}  does drop the 'integer64' class attribute.
+    \item \bold{\code{\link{array}}}  does drop the 'integer64' class attribute.
            In current R versions (1.15.1) this can be circumvented by activating the function
                         \code{as.vector.integer64} further down this file.
                         However, the CRAN maintainer has requested to remove \code{as.vector.integer64},
                         even at the price of breaking previously working functionality of the package.
 
-    \item \bold{code{link[=str]{str()}}} does not print the values of \code{integer64} correctly
+    \item \bold{\code{\link{str}}} does not print the values of \code{integer64} correctly
 
   }
 }
@@ -891,7 +891,7 @@ matplot(1:21, cbind(td32, t64), pch=c("d","i"), log="y")
   }
 
 }
-\seealso{ code{link[=integer]{integer()}} in base R }
+\seealso{ \code{\link{integer}} in base R }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 Maintainer: Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>

--- a/man/bit64S3.Rd
+++ b/man/bit64S3.Rd
@@ -50,11 +50,11 @@
 }
 \arguments{
   \item{x}{
-    integer64 vector: the values to be matched, optionally carrying a cache created with code{link[=hashcache]{hashcache()}}
+    integer64 vector: the values to be matched, optionally carrying a cache created with \code{\link{hashcache}}
 }
 
   \item{table}{
-    integer64 vector: the values to be matched against, optionally carrying a cache created with code{link[=hashcache]{hashcache()}} or code{link[=sortordercache]{sortordercache()}}
+    integer64 vector: the values to be matched against, optionally carrying a cache created with \code{\link{hashcache}} or \code{\link{sortordercache}}
 }
 
   \item{...}{ ignored }
@@ -64,7 +64,7 @@
   \item{to}{ scalar denoting last element of sequence }
 }
 \value{
-    code{link[=invisible]{invisible()}}
+    \code{\link{invisible}}
 }
 \description{
     Turn those base functions S3 generic which are used in bit64
@@ -73,23 +73,23 @@
    The following functions are turned into S3 gernerics in order to dispatch methods for \code{\link{integer64}}:
    \preformatted{
        \code{\link{:}}
-       code{link[=is.double]{is.double()}}
-       code{link[=match]{match()}}
+       \code{\link{is.double}}
+       \code{\link{match}}
        \code{\link{\%in\%}}
-       %code{link[=table]{table()}}
-       code{link[=rank]{rank()}}
-       code{link[=order]{order()}}
+       %\code{\link{table}}
+       \code{\link{rank}}
+       \code{\link{order}}
    }
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 }
 \note{
-    code{link[=is.double]{is.double()}} returns \code{FALSE} for \code{\link{integer64}} \cr
+    \code{\link{is.double}} returns \code{FALSE} for \code{\link{integer64}} \cr
     \code{\link{:}} currently only dispatches at its first argument, thus \code{as.integer64(1):9} works but \code{1:as.integer64(9)} doesn't
-    code{link[=match]{match()}} currently only dispatches at its first argument and expects its second argument also to be integer64, otherwise throws an error. Beware of something like \code{match(2, as.integer64(0:3))}
+    \code{\link{match}} currently only dispatches at its first argument and expects its second argument also to be integer64, otherwise throws an error. Beware of something like \code{match(2, as.integer64(0:3))}
     \code{\link{\%in\%}} currently only dispatches at its first argument and expects its second argument also to be integer64, otherwise throws an error. Beware of something like \code{2 \%in\% as.integer64(0:3)}
-    code{link[=order]{order()}} currently only orders a single argument, trying more than one raises an error
+    \code{\link{order}} currently only orders a single argument, trying more than one raises an error
 }
 \examples{
  is.double(as.integer64(1))
@@ -124,6 +124,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
  }
 }
 \seealso{
-    code{link[=bit64]{bit64()}}, \code{\link{S3}}
+    \code{\link{bit64}}, \code{\link{S3}}
 }
 \keyword{ methods }

--- a/man/c.integer64.Rd
+++ b/man/c.integer64.Rd
@@ -13,13 +13,13 @@
 \method{rbind}{integer64}(...)
 }
 \arguments{
-  \item{...}{ two or more arguments coerced to 'integer64' and passed to code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ two or more arguments coerced to 'integer64' and passed to \code{\link{NextMethod}} }
 
   \item{recursive}{ logical. If \code{recursive = TRUE}, the function recursively descends through lists (and pairlists) combining all their elements into a vector. }
 }
 \value{
-  code{link[=c]{c()}} returns a integer64 vector of the total length of the input \cr
-  code{link[=cbind]{cbind()}} and \code{\link{rbind}} return a integer64 matrix
+  \code{\link{c}} returns a integer64 vector of the total length of the input \cr
+  \code{\link{cbind}} and \code{\link{rbind}} return a integer64 matrix
 }
 \description{
   The ususal functions 'c', 'cbind' and 'rbind'
@@ -35,8 +35,8 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   cbind(1:6, as.integer(1:6))
   rbind(1:6, as.integer(1:6))
 }
-\seealso{ code{link[=rep.integer64]{rep.integer64()}} code{link[=seq.integer64]{seq.integer64()}}
-          code{link[=as.data.frame.integer64]{as.data.frame.integer64()}} \code{\link{integer64}}
+\seealso{ \code{\link{rep.integer64}} \code{\link{seq.integer64}}
+          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
 }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/cache.Rd
+++ b/man/cache.Rd
@@ -38,7 +38,7 @@ remcache(x)
 }
 
   \item{all.names, pattern}{
-  passed to code{link[=ls]{ls()}} when listing the cache content
+  passed to \code{\link{ls}} when listing the cache content
 }
 
   \item{...}{
@@ -88,7 +88,7 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
 \seealso{
  \code{\link[bit]{still.identical}} for testing whether to symbols point to the same RAM. \cr
     Functions that get and set small cache-content automatically when a cache is present: \code{\link[bit:Metadata]{na.count}}, \code{\link[bit:Metadata]{nvalid}}, \code{\link[bit:Metadata]{is.sorted}}, \code{\link[bit:Metadata]{nunique}} and \code{\link[bit:Metadata]{nties}} \cr
-    Setting big caches with a relevant memory footprint requires a conscious decision of the user: code{link[=hashcache]{hashcache()}}, code{link[=sortcache]{sortcache()}}, code{link[=ordercache]{ordercache()}} and code{link[=sortordercache]{sortordercache()}} \cr
-    Functions that use big caches: code{link[=match.integer64]{match.integer64()}}, \code{\link{\%in\%.integer64}}, code{link[=duplicated.integer64]{duplicated.integer64()}}, code{link[=unique.integer64]{unique.integer64()}}, \code{\link{unipos}}, code{link[=table.integer64]{table.integer64()}}, code{link[=keypos]{keypos()}}, \code{\link{tiepos}}, code{link[=rank.integer64]{rank.integer64()}}, \code{\link{prank}}, \code{\link{qtile}}, code{link[=quantile.integer64]{quantile.integer64()}}, code{link[=median.integer64]{median.integer64()}} and code{link[=summary.integer64]{summary.integer64()}} \cr
+    Setting big caches with a relevant memory footprint requires a conscious decision of the user: \code{\link{hashcache}}, \code{\link{sortcache}}, \code{\link{ordercache}} and \code{\link{sortordercache}} \cr
+    Functions that use big caches: \code{\link{match.integer64}}, \code{\link{\%in\%.integer64}}, \code{\link{duplicated.integer64}}, \code{\link{unique.integer64}}, \code{\link{unipos}}, \code{\link{table.integer64}}, \code{\link{keypos}}, \code{\link{tiepos}}, \code{\link{rank.integer64}}, \code{\link{prank}}, \code{\link{qtile}}, \code{\link{quantile.integer64}}, \code{\link{median.integer64}} and \code{\link{summary.integer64}} \cr
 }
 \keyword{ environment }

--- a/man/cumsum.integer64.Rd
+++ b/man/cumsum.integer64.Rd
@@ -21,16 +21,16 @@
 \arguments{
   \item{x}{ an atomic vector of class 'integer64'}
 
-  \item{lag}{ see code{link[=diff]{diff()}} }
+  \item{lag}{ see \code{\link{diff}} }
 
-  \item{differences}{ see code{link[=diff]{diff()}} }
+  \item{differences}{ see \code{\link{diff}} }
 
   \item{...}{ ignored }
 }
 \value{
-  code{link[=cummin]{cummin()}}, \code{\link{cummax}} , \code{\link{cumsum}} and \code{\link{cumprod}}
+  \code{\link{cummin}}, \code{\link{cummax}} , \code{\link{cumsum}} and \code{\link{cumprod}}
      return a integer64 vector of the same length as their input\cr
-  code{link[=diff]{diff()}} returns a integer64 vector shorter by \code{lag*differences} elements \cr
+  \code{\link{diff}} returns a integer64 vector shorter by \code{lag*differences} elements \cr
 }
 \description{
   Cumulative Sums, Products, Extremes and lagged differences
@@ -44,6 +44,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   cumsum(as.integer64(c(0, 1:12)))
   diff(cumsum(as.integer64(c(0,0,1:12))), differences=2)
 }
-\seealso{ code{link[=sum.integer64]{sum.integer64()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{sum.integer64}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/duplicated.integer64.Rd
+++ b/man/duplicated.integer64.Rd
@@ -41,7 +41,7 @@ duplicated(x)
 
 stopifnot(identical(duplicated(x),  duplicated(as.integer(x))))
 }
-\seealso{ code{link[=duplicated]{duplicated()}}, code{link[=unique.integer64]{unique.integer64()}}  }
+\seealso{ \code{\link{duplicated}}, \code{\link{unique.integer64}}  }
 \keyword{logic}
 \keyword{manip}
 

--- a/man/extract.replace.integer64.Rd
+++ b/man/extract.replace.integer64.Rd
@@ -21,7 +21,7 @@
 
   \item{i}{ indices specifying elements to extract }
 
-  \item{...}{ further arguments to the code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ further arguments to the \code{\link{NextMethod}} }
 
   \item{value}{ an atomic vector with values to be assigned }
 }

--- a/man/format.integer64.Rd
+++ b/man/format.integer64.Rd
@@ -62,24 +62,24 @@
 
   \item{justify}{ should it be right-justified (the default), left-justified, centred or left alone. }
 
-  \item{...}{ further arguments to the code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ further arguments to the \code{\link{NextMethod}} }
 
   \item{base}{ an atomic scalar (we save 50\% log-calls by not allowing a vector base) }
 
   \item{digits}{ integer indicating the number of decimal places (round) or significant digits (signif) to be used.
-                 Negative values are allowed (see code{link[=round]{round()}}) }
+                 Negative values are allowed (see \code{\link{round}}) }
 
-  \item{center}{ see code{link[=scale]{scale()}} }
+  \item{center}{ see \code{\link{scale}} }
 
-  \item{scale}{  see code{link[=scale]{scale()}} }
+  \item{scale}{  see \code{\link{scale}} }
 }
 \value{
-  code{link[=format]{format()}} returns a character vector \cr
-  code{link[=is.na]{is.na()}} and \code{\link{!}} return a logical vector \cr
-  code{link[=sqrt]{sqrt()}}, \code{\link{log}}, \code{\link{log2}} and \code{\link{log10}} return a double vector \cr
-  code{link[=sign]{sign()}}, \code{\link{abs}}, \code{\link{floor}}, \code{\link{ceiling}}, \code{\link{trunc}} and
-  code{link[=round]{round()}} return a vector of class 'integer64' \cr
-  code{link[=signif]{signif()}} is not implemented
+  \code{\link{format}} returns a character vector \cr
+  \code{\link{is.na}} and \code{\link{!}} return a logical vector \cr
+  \code{\link{sqrt}}, \code{\link{log}}, \code{\link{log2}} and \code{\link{log10}} return a double vector \cr
+  \code{\link{sign}}, \code{\link{abs}}, \code{\link{floor}}, \code{\link{ceiling}}, \code{\link{trunc}} and
+  \code{\link{round}} return a vector of class 'integer64' \cr
+  \code{\link{signif}} is not implemented
 }
 \description{
   Unary operators and functions for integer64 vectors.
@@ -98,6 +98,6 @@ r <- as.integer64(round(as.integer(i), s))
 }
 }
 }
-\seealso{ code{link[=xor.integer64]{xor.integer64()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{xor.integer64}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/hashcache.Rd
+++ b/man/hashcache.Rd
@@ -23,7 +23,7 @@ ordercache(x, has.na = NULL, stable = NULL, optimize = "time")
   \item{nunique}{ giving \emph{correct} number of unique elements can help reducing the size of the hashmap }
 
   \item{...}{
-        passed to code{link[=hashmap]{hashmap()}}
+        passed to \code{\link{hashmap}}
 }
 
   \item{has.na}{
@@ -41,13 +41,13 @@ set to 'memory' to minimize RAM requirements and sacrifice speed
 }
 }
 \value{
-    \code{x} with a code{link[=cache]{cache()}} that contains the result of the expensive operations, possible together with small derived information (such as code{link[=nunique.integer64]{nunique.integer64()}}) and previously cached results.
+    \code{x} with a \code{\link{cache}} that contains the result of the expensive operations, possible together with small derived information (such as \code{\link{nunique.integer64}}) and previously cached results.
 }
 \description{
     Functions to create cache that accelerates many operations
 }
 \details{
-    The result of relative expensive operations code{link[=hashmap]{hashmap()}}, \code{\link[=ramsort.integer64]{ramsort}}, \code{\link[=ramsort.integer64]{ramsortorder}} and \code{\link[=ramsort.integer64]{ramorder}} can be stored in a cache in order to avoid multiple excutions. Unless in very specific situations, the recommended method is \code{hashsortorder} only.
+    The result of relative expensive operations \code{\link{hashmap}}, \code{\link[=ramsort.integer64]{ramsort}}, \code{\link[=ramsort.integer64]{ramsortorder}} and \code{\link[=ramsort.integer64]{ramorder}} can be stored in a cache in order to avoid multiple excutions. Unless in very specific situations, the recommended method is \code{hashsortorder} only.
 }
 \note{
   Note that we consider storing the big results from sorting and/or ordering as a relevant side-effect,
@@ -61,6 +61,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
  sortordercache(x)
 }
 \seealso{
-    code{link[=cache]{cache()}} for caching functions and code{link[=nunique.integer64]{nunique.integer64()}} for methods benefiting from small caches
+    \code{\link{cache}} for caching functions and \code{\link{nunique.integer64}} for methods benefiting from small caches
 }
 \keyword{ environment }

--- a/man/hashmap.Rd
+++ b/man/hashmap.Rd
@@ -92,7 +92,7 @@ hashmaptab(x, ...)
 
   \item{nunique}{ giving \emph{correct} number of unique elements can help reducing the size of the hashmap }
 
-  \item{cache}{ an optional code{link[=cache]{cache()}} object into which to put the hashmap (by default a new cache is created)}
+  \item{cache}{ an optional \code{\link{cache}} object into which to put the hashmap (by default a new cache is created)}
 
   \item{nomatch}{ the value to be returned if an element is not found in the hashmap }
 
@@ -185,6 +185,6 @@ stopifnot(identical(hashtab(hy), hashmaptab(y)))
     message("we conclude that n*sqrt(2) is enough to avoid collisions")
     }
 }
-\seealso{ \code{\link[=match.integer64]{match}}, code{link[=runif64]{runif64()}} }
+\seealso{ \code{\link[=match.integer64]{match}}, \code{\link{runif64}} }
 \keyword{ programming }
 \keyword{ manip }

--- a/man/identical.integer64.Rd
+++ b/man/identical.integer64.Rd
@@ -13,19 +13,19 @@
   \item{x}{ atomic vector of class 'integer64' }
   \item{y}{ atomic vector of class 'integer64' }
 
-  \item{num.eq}{ see code{link[=identical]{identical()}} }
+  \item{num.eq}{ see \code{\link{identical}} }
 
-  \item{single.NA}{ see code{link[=identical]{identical()}} }
+  \item{single.NA}{ see \code{\link{identical}} }
 
-  \item{attrib.as.set}{ see code{link[=identical]{identical()}} }
+  \item{attrib.as.set}{ see \code{\link{identical}} }
 
-  \item{ignore.bytecode}{ see code{link[=identical]{identical()}} }
+  \item{ignore.bytecode}{ see \code{\link{identical}} }
 
-  \item{ignore.environment}{ see code{link[=identical]{identical()}} }
+  \item{ignore.environment}{ see \code{\link{identical}} }
 
-  \item{ignore.srcref}{ see code{link[=identical]{identical()}} }
+  \item{ignore.srcref}{ see \code{\link{identical}} }
 
-  \item{extptr.as.ref}{ see code{link[=identical]{identical()}} }
+  \item{extptr.as.ref}{ see \code{\link{identical}} }
 }
 \value{
   A single logical value, \code{TRUE} or \code{FALSE}, never \code{NA} and never anything other than a single value.
@@ -34,7 +34,7 @@
   This will discover any deviation between objects containing integer64 vectors.
 }
 \details{
-  This is simply a wrapper to code{link[=identical]{identical()}} with default arguments \code{num.eq = FALSE, single.NA = FALSE}.
+  This is simply a wrapper to \code{\link{identical}} with default arguments \code{num.eq = FALSE, single.NA = FALSE}.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
@@ -44,6 +44,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   identical(i64-1, i64+1)
   identical.integer64(i64-1, i64+1)
 }
-\seealso{ \code{\link{==.integer64}} code{link[=identical]{identical()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{==.integer64}} \code{\link{identical}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/is.sorted.integer64.Rd
+++ b/man/is.sorted.integer64.Rd
@@ -34,17 +34,17 @@
     These methods are packaged here for methods in packages \code{bit64} and \code{ff}.
 }
 \details{
-  All these functions benefit from a code{link[=sortcache]{sortcache()}}, code{link[=ordercache]{ordercache()}} or code{link[=sortordercache]{sortordercache()}}.
-  \code{na.count}, \code{nvalid} and \code{nunique} also benefit from a code{link[=hashcache]{hashcache()}}.
+  All these functions benefit from a \code{\link{sortcache}}, \code{\link{ordercache}} or \code{\link{sortordercache}}.
+  \code{na.count}, \code{nvalid} and \code{nunique} also benefit from a \code{\link{hashcache}}.
     \cr
     \code{is.sorted} checks for sortedness of \code{x} (NAs sorted first) \cr
  \code{na.count} returns the number of \code{NA}s \cr
- \code{nvalid} returns the number of valid data points, usually code{link[=length]{length()}} minus \code{na.count}. \cr
+ \code{nvalid} returns the number of valid data points, usually \code{\link{length}} minus \code{na.count}. \cr
  \code{nunique} returns the number of unique values \cr
  \code{nties} returns the number of tied values.
 }
 \note{
-    If a code{link[=cache]{cache()}} exists but the desired value is not cached,
+    If a \code{\link{cache}} exists but the desired value is not cached,
  then these functions will store their result in the cache.
  We do not consider this a relevant side-effect,
  since these small cache results do not have a relevant memory footprint.
@@ -63,7 +63,7 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
  x
 }
 \seealso{
-    code{link[=cache]{cache()}} for caching functions and code{link[=sortordercache]{sortordercache()}} for functions creating big caches
+    \code{\link{cache}} for caching functions and \code{\link{sortordercache}} for functions creating big caches
 }
 \keyword{ environment }
 \keyword{ methods }

--- a/man/keypos.Rd
+++ b/man/keypos.Rd
@@ -23,7 +23,7 @@ keypos(x, ...)
   \code{keypos} returns the positions of the (fact table) elements that participate in their sorted unique subset (dimension table)
 }
 \details{
-  NAs are sorted first in the dimension table, see code{link[=ramorder.integer64]{ramorder.integer64()}}.
+  NAs are sorted first in the dimension table, see \code{\link{ramorder.integer64}}.
   \cr
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
   Suitable methods are \code{\link{sortorderkey}} (fast ordering)
@@ -39,7 +39,7 @@ keypos(x)
 stopifnot(identical(keypos(x),  match.integer64(x, sort(unique(x), na.last=FALSE))))
 }
 \seealso{
-  code{link[=unique.integer64]{unique.integer64()}} for the unique subset and code{link[=match.integer64]{match.integer64()}} for finding positions in a different vector.
+  \code{\link{unique.integer64}} for the unique subset and \code{\link{match.integer64}} for finding positions in a different vector.
 }
 \keyword{manip}
 \keyword{univar}

--- a/man/match.integer64.Rd
+++ b/man/match.integer64.Rd
@@ -11,11 +11,11 @@
 }
 \arguments{
   \item{x}{
-    integer64 vector: the values to be matched, optionally carrying a cache created with code{link[=hashcache]{hashcache()}}
+    integer64 vector: the values to be matched, optionally carrying a cache created with \code{\link{hashcache}}
 }
 
   \item{table}{
-    integer64 vector: the values to be matched against, optionally carrying a cache created with code{link[=hashcache]{hashcache()}} or code{link[=sortordercache]{sortordercache()}}
+    integer64 vector: the values to be matched against, optionally carrying a cache created with \code{\link{hashcache}} or \code{\link{sortordercache}}
 }
 
   \item{nomatch}{
@@ -125,7 +125,7 @@ stopifnot(identical("\%in\%.integer64"(x, table), as.integer(x) \%in\% as.intege
 }
 }
 \seealso{
-    code{link[=match]{match()}}
+    \code{\link{match}}
 }
 \keyword{manip}
 \keyword{logic}

--- a/man/optimizer64.data.Rd
+++ b/man/optimizer64.data.Rd
@@ -78,7 +78,7 @@ List of 16
 }
 \usage{data(optimizer64.data)}
 \description{
-  These are the results of calling code{link[=optimizer64]{optimizer64()}}
+  These are the results of calling \code{\link{optimizer64}}
 }
 \examples{
 data(optimizer64.data)

--- a/man/plusclass.Rd
+++ b/man/plusclass.Rd
@@ -28,7 +28,7 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   minusclass(c("inheritingclass","integer64"), "integer64")
 }
 \seealso{
-  code{link[=oldClass]{oldClass()}} \code{\link{integer64}}
+  \code{\link{oldClass}} \code{\link{integer64}}
 }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/prank.Rd
+++ b/man/prank.Rd
@@ -21,10 +21,10 @@
 }
 \description{
     Function \code{prank.integer64}  projects the values [min..max] via ranks [1..n] to [0..1].
-    code{link[=qtile.integer64]{qtile.integer64()}} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
+    \code{\link{qtile.integer64}} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
 }
 \details{
-    Function \code{prank.integer64} is based on code{link[=rank.integer64]{rank.integer64()}}.
+    Function \code{prank.integer64} is based on \code{\link{rank.integer64}}.
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
@@ -37,6 +37,6 @@ x <- x[!is.na(x)]
 stopifnot(identical(x,  unname(qtile(x, probs=prank(x)))))
 }
 \seealso{
-  code{link[=rank.integer64]{rank.integer64()}} for simple ranks and \code{\link{qtile}} for the inverse function quantiles.
+  \code{\link{rank.integer64}} for simple ranks and \code{\link{qtile}} for the inverse function quantiles.
 }
 \keyword{univar}

--- a/man/qtile.Rd
+++ b/man/qtile.Rd
@@ -56,7 +56,7 @@
   at the relative positions specified by \code{probs}.
 }
 \description{
-    Function code{link[=prank.integer64]{prank.integer64()}}  projects the values [min..max] via ranks [1..n] to [0..1].
+    Function \code{\link{prank.integer64}}  projects the values [min..max] via ranks [1..n] to [0..1].
     \code{qtile.ineger64} is the inverse function of 'prank.integer64' and projects [0..1] to [min..max].
 }
 \details{
@@ -87,6 +87,6 @@ x <- x[!is.na(x)]
 stopifnot(identical(x,  unname(qtile(x, probs=prank(x)))))
 }
 \seealso{
-  code{link[=rank.integer64]{rank.integer64()}} for simple ranks and \code{\link{quantile}} for quantiles.
+  \code{\link{rank.integer64}} for simple ranks and \code{\link{quantile}} for quantiles.
 }
 \keyword{univar}

--- a/man/ramsort.integer64.Rd
+++ b/man/ramsort.integer64.Rd
@@ -55,7 +55,7 @@
 , optimize = c("time", "memory"), VERBOSE = FALSE, ...)
 }
 \arguments{
-  \item{x}{ a vector to be sorted by code{link[=ramsort.integer64]{ramsort.integer64()}} and code{link[=ramsortorder.integer64]{ramsortorder.integer64()}}, i.e. the output of  code{link[=sort.integer64]{sort.integer64()}} }
+  \item{x}{ a vector to be sorted by \code{\link{ramsort.integer64}} and \code{\link{ramsortorder.integer64}}, i.e. the output of  \code{\link{sort.integer64}} }
 
   \item{has.na}{
 boolean scalar defining whether the input vector might contain \code{NA}s. If we know we don't have NAs, this may speed-up.
@@ -64,7 +64,7 @@ boolean scalar defining whether the input vector might contain \code{NA}s. If we
 
   \item{na.last}{
 boolean scalar telling ramsort whether to sort \code{NA}s last or first.
-\emph{Note} that 'boolean' means that there is no third option \code{NA} as in code{link[=sort]{sort()}}
+\emph{Note} that 'boolean' means that there is no third option \code{NA} as in \code{\link{sort}}
 }
 
   \item{decreasing}{
@@ -73,7 +73,7 @@ boolean scalar telling ramsort whether to sort increasing or decreasing
 
   \item{...}{ further arguments, passed from generics, ignored in methods }
 
-  \item{i}{ integer positions to be modified by code{link[=ramorder.integer64]{ramorder.integer64()}} and code{link[=ramsortorder.integer64]{ramsortorder.integer64()}}, default is 1:n, in this case the output is similar to code{link[=order.integer64]{order.integer64()}} }
+  \item{i}{ integer positions to be modified by \code{\link{ramorder.integer64}} and \code{\link{ramsortorder.integer64}}, default is 1:n, in this case the output is similar to \code{\link{order.integer64}} }
 
   \item{restlevel}{
 number of remaining recursionlevels before \code{quicksort} switches from recursing to \code{shellsort}
@@ -136,6 +136,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   s
   o
 }
-\seealso{ \code{\link[bit:Sorting]{ramsort}} for the generic, \code{ramsort.default} for the methods provided by package \code{ff}, code{link[=sort.integer64]{sort.integer64()}} for the sort interface and code{link[=sortcache]{sortcache()}} for caching the work of sorting}
+\seealso{ \code{\link[bit:Sorting]{ramsort}} for the generic, \code{ramsort.default} for the methods provided by package \code{ff}, \code{\link{sort.integer64}} for the sort interface and \code{\link{sortcache}} for caching the work of sorting}
 \keyword{ programming }
 \keyword{ manip }

--- a/man/rank.integer64.Rd
+++ b/man/rank.integer64.Rd
@@ -22,8 +22,8 @@
 }
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
-  Suitable methods are code{link[=sortorderrnk]{sortorderrnk()}} (fast ordering)
-and code{link[=orderrnk]{orderrnk()}} (memory saving ordering).
+  Suitable methods are \code{\link{sortorderrnk}} (fast ordering)
+and \code{\link{orderrnk}} (memory saving ordering).
 }
 \author{
     Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
@@ -36,6 +36,6 @@ stopifnot(identical(rank.integer64(x),  rank(as.integer(x)
 , na.last="keep", ties.method = "average")))
 }
 \seealso{
-  code{link[=order.integer64]{order.integer64()}}, code{link[=rank]{rank()}} and \code{\link{prank}} for percent rank.
+  \code{\link{order.integer64}}, \code{\link{rank}} and \code{\link{prank}} for percent rank.
 }
 \keyword{univar}

--- a/man/rep.integer64.Rd
+++ b/man/rep.integer64.Rd
@@ -9,10 +9,10 @@
 \arguments{
   \item{x}{ a vector of 'integer64' to be replicated }
 
-  \item{...}{ further arguments passed to code{link[=NextMethod]{NextMethod()}} }
+  \item{...}{ further arguments passed to \code{\link{NextMethod}} }
 }
 \value{
-  code{link[=rep]{rep()}} returns a integer64 vector
+  \code{\link{rep}} returns a integer64 vector
 }
 \description{
   Replicate elements of integer64 vectors
@@ -25,8 +25,8 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   rep(as.integer64(1:2), c(6,6))
   rep(as.integer64(1:2), length.out=6)
 }
-\seealso{ code{link[=c.integer64]{c.integer64()}} code{link[=rep.integer64]{rep.integer64()}}
-          code{link[=as.data.frame.integer64]{as.data.frame.integer64()}} \code{\link{integer64}}
+\seealso{ \code{\link{c.integer64}} \code{\link{rep.integer64}}
+          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
 }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/runif64.Rd
+++ b/man/runif64.Rd
@@ -13,7 +13,7 @@
 
   \item{max}{ upper inclusive bound for random numbers }
 
-  \item{replace}{ set to FALSE for sampleing from a finite pool, see code{link[=sample]{sample()}} }
+  \item{replace}{ set to FALSE for sampleing from a finite pool, see \code{\link{sample}} }
 }
 \value{
   a integer64 vector
@@ -42,7 +42,7 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   table(runif64(16, 1, 16, replace=TRUE))
 }
 \seealso{
-  code{link[=runif]{runif()}}, \code{\link{hashfun}}
+  \code{\link{runif}}, \code{\link{hashfun}}
 }
 \keyword{ classes }
 \keyword{distribution}

--- a/man/seq.integer64.Rd
+++ b/man/seq.integer64.Rd
@@ -7,7 +7,7 @@
 \method{seq}{integer64}(from = NULL, to = NULL, by = NULL, length.out = NULL, along.with = NULL, ...)
 }
 \arguments{
-  \item{from}{ integer64 scalar (in order to dispatch the integer64 method of code{link[=seq]{seq()}} }
+  \item{from}{ integer64 scalar (in order to dispatch the integer64 method of \code{\link{seq}} }
 
   \item{to}{ scalar }
 
@@ -28,7 +28,7 @@
 \details{
   \code{seq.integer64} does coerce its arguments 'from', 'to' and 'by' to \code{integer64}.
   If not provided, the argument 'by' is automatically determined as \code{+1} or \code{-1},
-  but the size of 'by' is not calculated as in code{link[=seq]{seq()}} (because this might result in a non-integer value).
+  but the size of 'by' is not calculated as in \code{\link{seq}} (because this might result in a non-integer value).
 }
 \note{
   In base R \code{\link{:}} currently is not generic and does not dispatch, see section "Limitations inherited from Base R" in \code{\link{integer64}}
@@ -41,8 +41,8 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   seq(as.integer64(1), 12, 2)
   seq(as.integer64(1), by=2, length.out=6)
 }
-\seealso{ code{link[=c.integer64]{c.integer64()}} code{link[=rep.integer64]{rep.integer64()}}
-          code{link[=as.data.frame.integer64]{as.data.frame.integer64()}} \code{\link{integer64}}
+\seealso{ \code{\link{c.integer64}} \code{\link{rep.integer64}}
+          \code{\link{as.data.frame.integer64}} \code{\link{integer64}}
 }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/sort.integer64.Rd
+++ b/man/sort.integer64.Rd
@@ -12,7 +12,7 @@
 , optimize = c("time", "memory"), VERBOSE = FALSE)
 }
 \arguments{
-  \item{x}{ a vector to be sorted by code{link[=ramsort.integer64]{ramsort.integer64()}} and code{link[=ramsortorder.integer64]{ramsortorder.integer64()}}, i.e. the output of  code{link[=sort.integer64]{sort.integer64()}} }
+  \item{x}{ a vector to be sorted by \code{\link{ramsort.integer64}} and \code{\link{ramsortorder.integer64}}, i.e. the output of  \code{\link{sort.integer64}} }
 
   \item{decreasing}{
 boolean scalar telling ramsort whether to sort increasing or decreasing
@@ -25,7 +25,7 @@ boolean scalar defining whether the input vector might contain \code{NA}s. If we
 
   \item{na.last}{
 boolean scalar telling ramsort whether to sort \code{NA}s last or first.
-\emph{Note} that 'boolean' means that there is no third option \code{NA} as in code{link[=sort]{sort()}}
+\emph{Note} that 'boolean' means that there is no third option \code{NA} as in \code{\link{sort}}
 }
 
   \item{stable}{
@@ -48,10 +48,10 @@ set to 'memory' to minimize RAM requirements and sacrifice speed
 }
 \description{
   Fast high-level methods for sorting and ordering.
-  These are wrappers to code{link[=ramsort.integer64]{ramsort.integer64()}} and friends and do not modify their arguments.
+  These are wrappers to \code{\link{ramsort.integer64}} and friends and do not modify their arguments.
 }
 \details{
- see code{link[=sort]{sort()}} and code{link[=order]{order()}}
+ see \code{\link{sort}} and \code{\link{order}}
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
@@ -66,6 +66,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   message("slower with less RAM, this calls 'ramsortorder'")
   order.integer64(x, optimize="memory")
 }
-\seealso{ \code{\link[=sort.integer64]{sort}}, code{link[=sortcache]{sortcache()}} }
+\seealso{ \code{\link[=sort.integer64]{sort}}, \code{\link{sortcache}} }
 \keyword{ programming }
 \keyword{ manip }

--- a/man/sortnut.Rd
+++ b/man/sortnut.Rd
@@ -150,7 +150,7 @@ sortorderrnk(sorted, order, na.count, ...)
 
   \item{table}{ the original data with original order under the sorted vector }
 
-  \item{order}{ an code{link[=integer]{integer()}} order vector that turns 'table' into 'sorted' }
+  \item{order}{ an \code{\link{integer}} order vector that turns 'table' into 'sorted' }
 
   \item{x}{ an \code{\link{integer64}} vector }
 

--- a/man/sum.integer64.Rd
+++ b/man/sum.integer64.Rd
@@ -32,12 +32,12 @@ lim.integer64()
 
   \item{na.rm}{ logical scalar indicating whether to ignore NAs }
 
-  \item{finite}{ logical scalar indicating whether to ignore NAs (just for compatibility with code{link[=range.default]{range.default()}}) }
+  \item{finite}{ logical scalar indicating whether to ignore NAs (just for compatibility with \code{\link{range.default}}) }
 }
 \value{
-  code{link[=all]{all()}} and \code{\link{any}} return a logical scalar\cr
-  code{link[=range]{range()}} returns a integer64 vector with two elements\cr
-  code{link[=min]{min()}}, \code{\link{max}}, \code{\link{sum}} and \code{\link{prod}} return a integer64 scalar
+  \code{\link{all}} and \code{\link{any}} return a logical scalar\cr
+  \code{\link{range}} returns a integer64 vector with two elements\cr
+  \code{\link{min}}, \code{\link{max}}, \code{\link{sum}} and \code{\link{prod}} return a integer64 scalar
 }
 \description{
   Summary functions for integer64 vectors.
@@ -49,7 +49,7 @@ lim.integer64()
   on empty arguments, but \code{+9223372036854775807, -9223372036854775807} (in this sequence).
   The same is true if only  \code{NA}s are submitted with argument \code{na.rm=TRUE}.
  \cr
-  \code{lim.integer64} returns these limits in proper order \code{-9223372036854775807, +9223372036854775807} and without a code{link[=warning]{warning()}}.
+  \code{lim.integer64} returns these limits in proper order \code{-9223372036854775807, +9223372036854775807} and without a \code{\link{warning}}.
 }
 \author{
 Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
@@ -58,6 +58,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   lim.integer64()
   range(as.integer64(1:12))
 }
-\seealso{ code{link[=mean.integer64]{mean.integer64()}} code{link[=cumsum.integer64]{cumsum.integer64()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{mean.integer64}} \code{\link{cumsum.integer64}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }

--- a/man/table.integer64.Rd
+++ b/man/table.integer64.Rd
@@ -40,15 +40,15 @@ table.integer64(...
     constructed.  See \sQuote{Details}.}
 }
 \value{
-  By default (with \code{return="table"}) code{link[=table]{table()}} returns a \emph{contingency table}, an object of
-  class \code{"table"}, an array of integer values. Note that unlike S the result is always an array, a 1D array if one factor is given. Note also that for multidimensional arrays this is a \emph{dense} return structure which can dramatically increase RAM requirements (for large arrays with high mutual information, i.e. many possible input combinations of which only few occur) and that code{link[=table]{table()}} is limited to \code{2^31} possible combinations (e.g. two input vectors with 46340 unique values only). Finally note that the tabulated values or value-combinations are represented as \code{dimnames} and that the implied conversion of values to strings can cause \emph{severe} performance problems since each string needs to be integrated into R's global string cache.
+  By default (with \code{return="table"}) \code{\link{table}} returns a \emph{contingency table}, an object of
+  class \code{"table"}, an array of integer values. Note that unlike S the result is always an array, a 1D array if one factor is given. Note also that for multidimensional arrays this is a \emph{dense} return structure which can dramatically increase RAM requirements (for large arrays with high mutual information, i.e. many possible input combinations of which only few occur) and that \code{\link{table}} is limited to \code{2^31} possible combinations (e.g. two input vectors with 46340 unique values only). Finally note that the tabulated values or value-combinations are represented as \code{dimnames} and that the implied conversion of values to strings can cause \emph{severe} performance problems since each string needs to be integrated into R's global string cache.
   \cr
   You can use the other \code{return=} options to cope with these problems, the potential combination limit is increased from \code{2^31} to \code{2^63} with these options, RAM is only rewquired for observed combinations and string conversion is avoided.
   \cr
-  With \code{return="data.frame"} you get a \emph{dense} representation as a code{link[=data.frame]{data.frame()}} (like that resulting from \code{as.data.frame(table(...))}) where only observed combinations are listed (each as a data.frame row) with the corresponding frequency counts (the latter as component
-  named by \code{responseName}).  This is the inverse of code{link[=xtabs]{xtabs()}}..
+  With \code{return="data.frame"} you get a \emph{dense} representation as a \code{\link{data.frame}} (like that resulting from \code{as.data.frame(table(...))}) where only observed combinations are listed (each as a data.frame row) with the corresponding frequency counts (the latter as component
+  named by \code{responseName}).  This is the inverse of \code{\link{xtabs}}..
   \cr
-  With \code{return="list"} you also get a \emph{dense} representation as a simple code{link[=list]{list()}} with components
+  With \code{return="list"} you also get a \emph{dense} representation as a simple \code{\link{list}} with components
   \item{values }{a integer64 vector of the technically tabulated values, for 1D this is the tabulated values themselves, for kD these are the values representing the potential combinations of input values}
   \item{counts}{the frequency counts}
   \item{dims}{only for kD: a list with the vectors of the unique values of the input dimensions}
@@ -71,11 +71,11 @@ and \code{\link{ordertab}} (memory saving ordering).
   \code{deparse.level = 1} uses the supplied argument if it is a symbol,
   and \code{deparse.level = 2} will deparse the argument.
 
-  Arguments \code{exclude}, \code{useNA}, are not supported, i.e. \code{NA}s are always tabulated, and, different from code{link[=table]{table()}} they are sorted first if \code{order="values"}.
+  Arguments \code{exclude}, \code{useNA}, are not supported, i.e. \code{NA}s are always tabulated, and, different from \code{\link{table}} they are sorted first if \code{order="values"}.
 }
 \note{
-  Note that by using code{link[=as.integer64.factor]{as.integer64.factor()}} we can also input
-  factors into \code{table.integer64} -- only the code{link[=levels]{levels()}} get lost.
+  Note that by using \code{\link{as.integer64.factor}} we can also input
+  factors into \code{table.integer64} -- only the \code{\link{levels}} get lost.
 }
 \examples{
 message("pure integer64 examples")
@@ -106,7 +106,7 @@ table.integer64(x, as.integer64(as.factor(z)))
 
 }
 \seealso{
-  code{link[=table]{table()}} for more info on the standard version coping with Base R's data types, code{link[=tabulate]{tabulate()}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, code{link[=unique.integer64]{unique.integer64()}} for the unique values without counting them and code{link[=unipos.integer64]{unipos.integer64()}} for the positions of the unique values.
+  \code{\link{table}} for more info on the standard version coping with Base R's data types, \code{\link{tabulate}} which can faster tabulate \code{\link{integer}s} with a limited range \code{[1L .. nL not too big]}, \code{\link{unique.integer64}} for the unique values without counting them and \code{\link{unipos.integer64}} for the positions of the unique values.
 }
 \concept{counts}
 \concept{frequencies}

--- a/man/tiepos.Rd
+++ b/man/tiepos.Rd
@@ -41,7 +41,7 @@ tiepos(x)
 stopifnot(identical(tiepos(x),  (1:length(x))[duplicated(x) | rev(duplicated(rev(x)))]))
 }
 \seealso{
-  code{link[=rank.integer64]{rank.integer64()}} for possibly tied ranks and code{link[=unipos.integer64]{unipos.integer64()}} for positions of unique values.
+  \code{\link{rank.integer64}} for possibly tied ranks and \code{\link{unipos.integer64}} for positions of unique values.
 }
 \keyword{manip}
 \keyword{univar}

--- a/man/unipos.Rd
+++ b/man/unipos.Rd
@@ -29,7 +29,7 @@ unipos(x, incomparables = FALSE, order = c("original","values","any"), ...)
   an integer vector of positions
 }
 \description{
-  \code{unipos} returns the positions of those elements returned by code{link[=unique]{unique()}}.
+  \code{unipos} returns the positions of those elements returned by \code{\link{unique}}.
 }
 \details{
   This function automatically chooses from several low-level functions considering the size of \code{x} and the availability of a cache.
@@ -38,8 +38,8 @@ unipos(x, incomparables = FALSE, order = c("original","values","any"), ...)
 , \code{\link{sortorderupo}} (fast ordering)
 and \code{\link{orderupo}} (memory saving ordering).
 \cr
-The default \code{order="original"} collects unique values in the order of the first appearance in \code{x} like in code{link[=unique]{unique()}}, this costs extra processing.
-\code{order="values"} collects unique values in sorted order like in code{link[=table]{table()}}, this costs extra processing with the hash methods but comes for free.
+The default \code{order="original"} collects unique values in the order of the first appearance in \code{x} like in \code{\link{unique}}, this costs extra processing.
+\code{order="values"} collects unique values in sorted order like in \code{\link{table}}, this costs extra processing with the hash methods but comes for free.
 \code{order="any"} collects unique values in undefined order, possibly faster. For hash methods this will be a quasi random order, for sort methods this will be sorted order.
 }
 \author{
@@ -57,7 +57,7 @@ stopifnot(identical(unique(x),  x[unipos(x)]))
 stopifnot(identical(unique(x, order="values"),  x[unipos(x, order="values")]))
 }
 \seealso{
-  code{link[=unique.integer64]{unique.integer64()}} for unique values and code{link[=match.integer64]{match.integer64()}} for general matching.
+  \code{\link{unique.integer64}} for unique values and \code{\link{match.integer64}} for general matching.
 }
 \keyword{manip}
 \keyword{logic}

--- a/man/unique.integer64.Rd
+++ b/man/unique.integer64.Rd
@@ -38,8 +38,8 @@
 , \code{\link{sortorderuni}} (fast ordering for original order only)
 and \code{\link{orderuni}} (memory saving ordering).
 \cr
-The default \code{order="original"} returns unique values in the order of the first appearance in \code{x} like in code{link[=unique]{unique()}}, this costs extra processing.
-\code{order="values"} returns unique values in sorted order like in code{link[=table]{table()}}, this costs extra processing with the hash methods but comes for free.
+The default \code{order="original"} returns unique values in the order of the first appearance in \code{x} like in \code{\link{unique}}, this costs extra processing.
+\code{order="values"} returns unique values in sorted order like in \code{\link{table}}, this costs extra processing with the hash methods but comes for free.
 \code{order="any"} returns unique values in undefined order, possibly faster. For hash methods this will be a quasi random order, for sort methods this will be sorted order.
 }
 \author{
@@ -56,8 +56,8 @@ stopifnot(identical(unique(x, order="values")
 ,  as.integer64(sort(unique(as.integer(x)), na.last=FALSE))))
 }
 \seealso{
-  code{link[=unique]{unique()}} for the generic, \code{\link{unipos}} which gives the indices of the unique
-  elements and code{link[=table.integer64]{table.integer64()}} which gives frequencies of the unique elements.
+  \code{\link{unique}} for the generic, \code{\link{unipos}} which gives the indices of the unique
+  elements and \code{\link{table.integer64}} which gives frequencies of the unique elements.
 }
 \keyword{manip}
 \keyword{logic}

--- a/man/xor.integer64.Rd
+++ b/man/xor.integer64.Rd
@@ -64,7 +64,7 @@ binattr(e1,e2) # for internal use only
   \item{y}{ an atomic vector of class 'integer64'}
 }
 \value{
-  \code{\link{&}}, \code{\link{|}}, code{link[=xor]{xor()}}, \code{\link{!=}}, \code{\link{==}},
+  \code{\link{&}}, \code{\link{|}}, \code{\link{xor}}, \code{\link{!=}}, \code{\link{==}},
   \code{\link{<}}, \code{\link{<=}}, \code{\link{>}}, \code{\link{>=}} return a logical vector \cr
   \code{\link{^}} and \code{\link{/}} return a double vector\cr
   \code{\link{+}}, \code{\link{-}}, \code{\link{*}}, \code{\link{\%/\%}}, \code{\link{\%\%}}
@@ -89,6 +89,6 @@ Jens Oehlschlägel <Jens.Oehlschlaegel@truecluster.com>
   d*i  # old: 10
   i*d  # old: 13
 }
-\seealso{ code{link[=format.integer64]{format.integer64()}} \code{\link{integer64}}  }
+\seealso{ \code{\link{format.integer64}} \code{\link{integer64}}  }
 \keyword{ classes }
 \keyword{ manip }


### PR DESCRIPTION
Reverts r-lib/bit64#73. It dropped `\`.