### PR TITLE
Add required testthat version for expect_no_match

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ URL: https://github.com/r-lib/bit64
 Encoding: UTF-8
 Imports: graphics, methods, stats, utils
 Suggests: 
-    testthat (>= 3.0.0),
+    testthat (>= 3.0.3),
     withr
 Config/testthat/edition: 3
 Config/needs/development: testthat


### PR DESCRIPTION
Ref:

https://github.com/r-lib/testthat/blob/fe38519d72247a8907228a4ecaf926483aa5d4ff/NEWS.md?plain=1#L457-L459