### PR TITLE
Correct Rboolean usage --> int

### DIFF
--- a/src/integer64.c
+++ b/src/integer64.c
@@ -520,7 +520,7 @@ SEXP log2_integer64(SEXP e1_, SEXP ret_){
 SEXP any_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_){
   long long i, n = LENGTH(e1_);
   long long * e1 = (long long *) REAL(e1_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
   Rboolean hasna=FALSE;
     if (asLogical(na_rm_)){
         for(i=0; i<n; i++){
@@ -547,7 +547,7 @@ SEXP any_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_){
 SEXP all_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_){
   long long i, n = LENGTH(e1_);
   long long * e1 = (long long *) REAL(e1_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
   Rboolean hasna=FALSE;
     if (asLogical(na_rm_)){
         for(i=0; i<n; i++){
@@ -856,7 +856,7 @@ SEXP seq_integer64(SEXP from_, SEXP by_, SEXP ret_){
 SEXP isna_integer64(SEXP e1_, SEXP ret_){
   long long i, n = XLENGTH(ret_);
   long long * e1 = (long long *) REAL(e1_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     for(i=0; i<n; i++) {
         ret[i] = (e1[i]==NA_INTEGER64) ? TRUE : FALSE;
     }
@@ -869,7 +869,7 @@ SEXP EQ_integer64(SEXP e1_, SEXP e2_, SEXP ret_){
   long long i2, n2 = LENGTH(e2_);
   long long * e1 = (long long *) REAL(e1_);
   long long * e2 = (long long *) REAL(e2_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     mod_iterate(n1, n2, i1, i2) {
         EQ64(e1[i1],e2[i2],ret[i])
     }
@@ -882,7 +882,7 @@ SEXP NE_integer64(SEXP e1_, SEXP e2_, SEXP ret_){
   long long i2, n2 = LENGTH(e2_);
   long long * e1 = (long long *) REAL(e1_);
   long long * e2 = (long long *) REAL(e2_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     mod_iterate(n1, n2, i1, i2) {
         NE64(e1[i1],e2[i2],ret[i])
     }
@@ -895,7 +895,7 @@ SEXP LT_integer64(SEXP e1_, SEXP e2_, SEXP ret_){
   long long i2, n2 = LENGTH(e2_);
   long long * e1 = (long long *) REAL(e1_);
   long long * e2 = (long long *) REAL(e2_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     mod_iterate(n1, n2, i1, i2) {
         LT64(e1[i1],e2[i2],ret[i])
     }
@@ -908,7 +908,7 @@ SEXP LE_integer64(SEXP e1_, SEXP e2_, SEXP ret_){
   long long i2, n2 = LENGTH(e2_);
   long long * e1 = (long long *) REAL(e1_);
   long long * e2 = (long long *) REAL(e2_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     mod_iterate(n1, n2, i1, i2) {
         LE64(e1[i1],e2[i2],ret[i])
     }
@@ -921,7 +921,7 @@ SEXP GT_integer64(SEXP e1_, SEXP e2_, SEXP ret_){
   long long i2, n2 = LENGTH(e2_);
   long long * e1 = (long long *) REAL(e1_);
   long long * e2 = (long long *) REAL(e2_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     mod_iterate(n1, n2, i1, i2) {
         GT64(e1[i1],e2[i2],ret[i])
     }
@@ -934,7 +934,7 @@ SEXP GE_integer64(SEXP e1_, SEXP e2_, SEXP ret_){
   long long i2, n2 = LENGTH(e2_);
   long long * e1 = (long long *) REAL(e1_);
   long long * e2 = (long long *) REAL(e2_);
-  Rboolean * ret = (Rboolean *) LOGICAL(ret_);
+  int * ret = (int *) LOGICAL(ret_);
     mod_iterate(n1, n2, i1, i2) {
         GE64(e1[i1],e2[i2],ret[i])
     }

--- a/src/sort64.c
+++ b/src/sort64.c
@@ -1533,9 +1533,9 @@ SEXP r_ram_integer64_shellsort(
   int ret;
 
   int n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   R_Busy(1);
   DEBUG_INIT
@@ -1572,9 +1572,9 @@ SEXP r_ram_integer64_shellsortorder(
   int ret;
 
   int n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
     R_Busy(1);
     DEBUG_INIT
@@ -1614,9 +1614,9 @@ SEXP r_ram_integer64_shellorder(
   int ret;
 
   int i,n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
     R_Busy(1);
     DEBUG_INIT
@@ -1663,9 +1663,9 @@ SEXP r_ram_integer64_mergesort(
   int ret;
 
   int i,n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   R_Busy(1);
   DEBUG_INIT
@@ -1707,9 +1707,9 @@ SEXP r_ram_integer64_mergesortorder(
   int ret;
 
   int i,n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   R_Busy(1);
   DEBUG_INIT
@@ -1758,9 +1758,9 @@ SEXP r_ram_integer64_mergeorder(
   int ret;
 
   int i,n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   R_Busy(1);
   DEBUG_INIT
@@ -1812,9 +1812,9 @@ SEXP r_ram_integer64_quicksort(
   int ret;
 
   int n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
   int restlevel = asInteger(restlevel_);
 
   R_Busy(1);
@@ -1853,9 +1853,9 @@ SEXP r_ram_integer64_quicksortorder(
   int ret;
 
   int n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
   int restlevel = asInteger(restlevel_);
 
     R_Busy(1);
@@ -1897,9 +1897,9 @@ SEXP r_ram_integer64_quickorder(
   int ret;
 
   int i,n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
   int restlevel = asInteger(restlevel_);
 
     R_Busy(1);
@@ -1949,9 +1949,9 @@ SEXP r_ram_integer64_radixsort(
   DEBUG_INIT
 
   IndexT n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
   int radixbits = asInteger(radixbits_);
   int nradixes = 64 / radixbits;
 
@@ -2002,9 +2002,9 @@ SEXP r_ram_integer64_radixsortorder(
   R_Busy(1);
   DEBUG_INIT
   IndexT n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
   int radixbits = asInteger(radixbits_);
   int nradixes = 64 / radixbits;
 
@@ -2061,9 +2061,9 @@ SEXP r_ram_integer64_radixorder(
   R_Busy(1);
   DEBUG_INIT
   IndexT i,n = LENGTH(x_);
-  Rboolean has_na     = asLogical(has_na_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int has_na     = asLogical(has_na_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
   int radixbits = asInteger(radixbits_);
   int nradixes = 64 / radixbits;
 

--- a/src/sortuse64.c
+++ b/src/sortuse64.c
@@ -1160,9 +1160,9 @@ SEXP r_ram_integer64_sortsrt(
   DEBUG_INIT
 
   int i,j,l,r,n = LENGTH(x_);
-  Rboolean na_count   = asInteger(na_count_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int na_count   = asInteger(na_count_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   ValueT *sorted;
   sorted = (ValueT *) REAL(x_);
@@ -1211,9 +1211,9 @@ SEXP r_ram_integer64_sortorderord(
   DEBUG_INIT
 
   int i,j,l,r,n = LENGTH(x_);
-  Rboolean na_count   = asInteger(na_count_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int na_count   = asInteger(na_count_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   ValueT *sorted;
   sorted = (ValueT *) REAL(x_);
@@ -1263,9 +1263,9 @@ SEXP r_ram_integer64_orderord(
   DEBUG_INIT
 
   int i,j,l,r,n = LENGTH(x_);
-  Rboolean na_count   = asInteger(na_count_);
-  Rboolean na_last    = asLogical(na_last_);
-  Rboolean decreasing = asLogical(decreasing_);
+  int na_count   = asInteger(na_count_);
+  int na_last    = asLogical(na_last_);
+  int decreasing = asLogical(decreasing_);
 
   ValueT *data;
   data = (ValueT *) REAL(x_);


### PR DESCRIPTION
As flagged by @aitap on r-devel:

https://stat.ethz.ch/pipermail/r-devel/2025-February/083816.html

Also `asLogical()` and `asInteger()` both return `int`.

https://github.com/r-devel/r-svn/blob/6d28c1d0d3298ef02ff367114bb7c8b1bc8c5c85/src/include/Rinternals.h#L486-L487