### PR TITLE
Add an escape valve for false positive warnings of direct calls to exported S3 methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
    `as.integer64.bitstring` is a new addition here -- on follow-up, the only references were in old
    (e.g. 2020) Advent of Code solutions and archived repos.
 
+   To disable this warning, use `options(bit64.warn.exported.s3.method = FALSE)`.
+
 1. The following S3 methods were directly removed from the NAMESPACE:
 
    `-.integer64`, `!.integer64`, `!=.integer64`, `*.integer64`, `/.integer64`, `&.integer64`, `%/%.integer64`, `%%.integer64`, `^.integer64`, `+.integer64`, `<.integer64`, `<=.integer64`, `==.integer64`, `>.integer64`, `>=.integer64`, `|.integer64`, `ceiling.integer64`, `cummax.integer64`, `cummin.integer64`, `cumprod.integer64`, `cumsum.integer64`, `floor.integer64`, `log10.integer64`, `log2.integer64`, `prod.integer64`, `range.integer64`, `round.integer64`, `sign.integer64`, `signif.integer64`, `sqrt.integer64`, `trunc.integer64`

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -69,14 +69,21 @@ deprecate_exported_s3_methods <- function(..., verbose=FALSE) {
     }
 
     # Prepend the warning check to the function body
-    warning_expr <- bquote(if (!generic_call_in_stack(.(generic_name))) {
-      warning(
-        "Don't call '", .(method_name), "' directly. ",
-        "Instead only call '", .(generic_name), "' and rely on S3 dispatch. ",
-        "In the next version, this symbol will stop being exported.",
-        domain=NA
-      )
-    })
+    warning_expr <- bquote(
+      if (
+        getOption("bit64.warn.exported.s3.method", TRUE) &&
+          !generic_call_in_stack(.(generic_name))
+      ) {
+        warning(
+          "Detected that '", .(method_name), "' was called directly. ",
+          "Instead only call '", .(generic_name), "' and rely on S3 dispatch. ",
+          "To suppress this warning, e.g. if this is a false positive, ",
+          "use options(bit64.warn.exported.s3.method = FALSE). ",
+          "In the next version, this symbol will stop being exported.",
+          domain=NA
+        )
+      }
+    )
 
     # in 'function(x) x', body() is a name --> subsetting breaks
     # if un-braced, as.list() will break up the first (and only) expression


### PR DESCRIPTION
It's pretty easy to fool the call stack inspection mechanism:

```r
foo = `:`
foo(as.integer64(1), as.integer64(2))
# integer64
# [1] 1 2
```

```
Warning message:
In `:.integer64`(as.integer64(1), as.integer64(2)) :
  Detected that ':.integer64' was called directly. Instead only call ':' and rely on S3 dispatch. In the next version, this symbol will stop being exported.
```

Getting the `eval()` right to associate ``identical(foo, `:`)`` is tricky; mostly I expect this issue arises in testing, so for now just offer a test-friendly workaround.