### PR TITLE
Support conversion of hexidecimal values

### DIFF
--- a/src/integer64.c
+++ b/src/integer64.c
@@ -156,7 +156,12 @@ SEXP as_integer64_character(SEXP x_, SEXP ret_){
   char * endpointer;
   for(i=0; i<n; i++){
     str = CHAR(STRING_ELT(x_, i)); endpointer = (char *)str; // thanks to Murray Stokely 28.1.2012
-    ret[i] = strtoll(str, &endpointer, 10);
+    int base = 10; // default
+    if (str[0]=='0' && (str[1] == 'x' || str[1] == 'X')){
+        base = 16;
+        str += 2;
+    }
+    ret[i] = strtoll(str, &endpointer, base);
     if (*endpointer)
       ret[i] = NA_INTEGER64;
   }

--- a/tests/testthat/test-integer64.R
+++ b/tests/testthat/test-integer64.R
@@ -9,6 +9,8 @@ test_that("integer64 coercion to/from other types work", {
   # to integer64
   expect_identical(as.integer64(TRUE), as.integer64(1L))
   expect_identical(as.integer64(as.character(1:10)), as.integer64(1:10))
+  expect_identical(as.integer64(c("0x1", "0xF")), as.integer64(c(1, 15)))
+  expect_identical(as.integer64(c("0x100000000")), as.integer64(2^32))
   expect_identical(as.integer64(as.double(1:10)), as.integer64(1:10))
   expect_identical(as.integer64(NULL), as.integer64())
   x = as.integer64(1:10)


### PR DESCRIPTION
This small addition allows `as.integer64.character` to handle hexidecimal printed representation of large integers, in the style of `as.integer` in base R.