### PR TITLE
fix intdiv and modulo

### DIFF
--- a/R/integer64.R
+++ b/R/integer64.R
@@ -1574,13 +1574,9 @@ scale.integer64 = function(x, center = TRUE, scale = TRUE) {
 round.integer64 = function(x, digits=0L) {
   if (digits >= 0L) return(x)
   a = attributes(x)
-  b = 10L^round(-digits)
-  b2 = b %/% 2L
-  d = (x %/% b)
-  db = d * b
-  r = abs(x-db)
-  ret = ifelse((r < b2) | (r == b2 & ((d %% 2L) == 0L)), db, db + sign(x)*b)
-  #a$class = minusclass(a$class, "integer64")
+  b = as.integer64(10L^round(-digits))
+  b2 = b%/%2L
+  ret = ((x + b2 - (((x - b2)%%(2L*b)) == 0L)) %/% b)*b
   attributes(ret) = a
   ret
 }

--- a/src/integer64.h
+++ b/src/integer64.h
@@ -176,7 +176,7 @@ else {                                                   \
             ret = e1 / e2; \
         if (ret == NA_INTEGER64) \
             naflag = TRUE; \
-        else if (ret < 0 && ret*e2 != e1) \
+        else if ((e1^e2) < 0 && ret*e2 != e1) \
             ret -= 1; \
     }
 
@@ -192,7 +192,7 @@ else {                                                   \
         if (ret == NA_INTEGER64) \
             naflag = TRUE; \
         else { \
-            if (ret < 0 && ret*e2 != e1) \
+            if ((e1^e2) < 0 && ret*e2 != e1) \
                 ret -= 1; \
             ret = e1 - e2 * ret; \
             } \

--- a/tests/testthat/test-integer64.R
+++ b/tests/testthat/test-integer64.R
@@ -325,13 +325,13 @@ test_that("arithmetic & basic math works", {
   expect_identical(x %/% 2L, as.integer64(c(0L, 1L, 1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L)))
   expect_identical(x %% 2L, as.integer64(rep_len(c(1L, 0L), 10L)))
   
-  x32 = c(10L, 10L, -10L, -10L, 10L, -10L)
-  y32 = c(3L, -3L, 3L, -3L, 0L, 0L)
+  x32 = c(10L, 10L, -10L, -10L, 7L, 10L, -10L)
+  y32 = c(3L, -3L, 3L, -3L, -10L, 0L, 0L)
   x64 = as.integer64(x32)
   y64 = as.integer64(y32)
-  expect_warning(expect_identical(as.integer64(x32) %/% as.integer64(y32), as.integer64(x32 %/% y32)), "NAs produced due to division by zero")
-  expect_warning(expect_identical(as.integer64(x32) %% as.integer64(y32), as.integer64(x32 %% y32)), "NAs produced due to division by zero")
-  expect_identical(suppressWarnings((x64%/%y64)*y64 + x64%%y64 == x64), c(rep(TRUE, 4L), rep(NA, 2L)))
+  expect_warning(expect_identical(x64%/%y64, as.integer64(x32 %/% y32)), "NAs produced due to division by zero")
+  expect_warning(expect_identical(x64%%y64, as.integer64(x32 %% y32)), "NAs produced due to division by zero")
+  expect_identical(suppressWarnings((x64%/%y64)*y64 + x64%%y64 == x64), c(rep(TRUE, 5L), rep(NA, 2L)))
   
   expect_identical(sign(x - 6L), as.integer64(rep(c(-1L, 0L, 1L), c(5L, 1L, 4L))))
   expect_identical(abs(x - 6.0), as.integer64(c(5:0, 1:4)))


### PR DESCRIPTION
In PR #248 the following case was overseen, which is not consistent to R:
```
7L%%(-10L)
# [1] -3
as.integer64(7L)%%(-10L)
# integer64
# [1] 7
```
This is fixed now.

I had to change `round.integer64` because of the change. Now it is faster, too.