### PR TITLE
remove x,y arguments no longer used in ?ops64

### DIFF
--- a/R/ops64.R
+++ b/R/ops64.R
@@ -14,8 +14,6 @@
 #'
 #' @param e1 an atomic vector of class 'integer64'
 #' @param e2 an atomic vector of class 'integer64'
-#' @param x an atomic vector of class 'integer64'
-#' @param y an atomic vector of class 'integer64'
 #'
 #' @returns
 #'   [`&`], [`|`], [xor()], [`!=`], [`==`],

--- a/man/ops64.Rd
+++ b/man/ops64.Rd
@@ -56,10 +56,6 @@ binattr(e1, e2)
 \item{e1}{an atomic vector of class 'integer64'}
 
 \item{e2}{an atomic vector of class 'integer64'}
-
-\item{x}{an atomic vector of class 'integer64'}
-
-\item{y}{an atomic vector of class 'integer64'}
 }
 \value{
 \code{\link{&}}, \code{\link{|}}, \code{\link[bit:xor]{bit::xor()}}, \code{\link{!=}}, \code{\link{==}},


### PR DESCRIPTION
Follow up to #270 -- I merged before observing any `R CMD check` output