### PR TITLE
Catch generic as mapper in call stack

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,7 +41,8 @@ if (getRversion() < "3.6.0") {
 generic_call_in_stack = function(generic_name) {
   calls = sys.calls()
   # we define `:.default` --> avoid infinite loop
-  for (jj in base::`:`(length(calls), 1L)) {
+  # -2: tail is always this function, -2 is the method calling this function
+  for (jj in base::`:`(length(calls) - 2L, 1L)) {
     this_call = calls[[jj]][[1L]]
     if (identical(this_call, as.name(generic_name))) return(TRUE)
     if (is.call(this_call)) {
@@ -51,6 +52,13 @@ generic_call_in_stack = function(generic_name) {
     } else if (is.function(this_call)) {
       # substitute() equivalent
       if (identical(this_call, get(generic_name))) return(TRUE)
+    } else if (identical(this_call, quote(FUN))) { # sapply, lapply, Map, mapply, apply, ...
+      FUN = evalq(FUN, parent.frame(length(calls) - jj))
+      if (identical(FUN, get(generic_name))) return(TRUE)
+      if (identical(FUN, generic_name)) return(TRUE) # sapply(x, "is.double")
+    } else if (identical(this_call, quote(.f))) { # purrr mappers
+      .f = evalq(.f, parent.frame(length(calls) - jj))
+      if (identical(.f, get(generic_name))) return(TRUE)
     }
   }
   FALSE

--- a/tests/testthat/test-patch64.R
+++ b/tests/testthat/test-patch64.R
@@ -30,3 +30,17 @@ test_that("Old \\dontshow{} tests continue working", {
   expect_identical(order(zi64), order(zi))
   expect_identical(order(zi64, decreasing=TRUE), order(zi, decreasing=TRUE))
 })
+
+test_that("generic invoked from sapply doesn't throw warning", {
+  expect_no_warning(expect_true(sapply(1.0, is.double)))
+  expect_no_warning(expect_true(sapply(1.0, 'is.double')))
+
+  # simulating purrr::map
+  map = function(.x, .f) {
+    type = typeof(.f(.x[0L]))
+    out = vector(type, length(.x))
+    for (jj in seq_along(.x)) out[jj] = .f(.x[[jj]])
+    out
+  }
+  expect_no_warning(expect_true(map(1.0, is.double)))
+})


### PR DESCRIPTION
Closes #273. But the situation leaves me no confidence this `generic_call_in_stack()` hack is worth pushing to CRAN...