### PR TITLE
Update revdep script

### DIFF
--- a/.dev/revdepcheck.R
+++ b/.dev/revdepcheck.R
@@ -115,9 +115,3 @@ cat(sprintf(
 ))
 
 setdiff(failing_pkgs, failing_on_cran)
-
-
-set.seed(1L)
-bit64::factor(sample(letters[1:3], 10L, replace=TRUE), levels=letters[1:5])
-set.seed(1L)
-base::factor(sample(letters[1:3], 10L, replace=TRUE), levels=letters[1:5])


### PR DESCRIPTION
This only covers level-1 reverse dependencies. I'd like to extend it to level-2 (direct-deps-of-direct-deps) before CRAN submission, but only after incorporating the other PRs in the pipeline.