### PR TITLE
keep.names= for double input to as.integer64() too

### DIFF
--- a/R/integer64.R
+++ b/R/integer64.R
@@ -563,9 +563,10 @@ as.integer64.integer64 = function(x, ..., keep.names=FALSE) {
 
 #' @rdname as.integer64.character
 #' @export
-as.integer64.double = function(x, ...) {
+as.integer64.double = function(x, ..., keep.names=FALSE) {
   ret = .Call(C_as_integer64_double, x, double(length(x)))
   oldClass(ret) = "integer64"
+  if (isTRUE(keep.names)) names(ret) = names(x)
   ret
 }
 

--- a/man/as.integer64.character.Rd
+++ b/man/as.integer64.character.Rd
@@ -29,7 +29,7 @@ as.integer64(x, ...)
 
 \method{as.integer64}{integer64}(x, ..., keep.names = FALSE)
 
-\method{as.integer64}{double}(x, ...)
+\method{as.integer64}{double}(x, ..., keep.names = FALSE)
 
 \method{as.integer64}{complex}(x, ...)
 

--- a/tests/testthat/test-integer64.R
+++ b/tests/testthat/test-integer64.R
@@ -1569,4 +1569,7 @@ test_that("back-compatible keep.names=TRUE is supported for limited input classe
   x = as.integer64(1L)
   names(x) = "a"
   expect_named(as.integer64(x, keep.names=TRUE), "a")
+
+  y = c(a = 1.0)
+  expect_named(as.integer64(y, keep.names=TRUE), "a")
 })


### PR DESCRIPTION
For #301. {nanotime} uses this too:

https://github.com/eddelbuettel/nanotime/blob/e2486c401cc9ee2f75d36fdf7a36465e212b3998/inst/tinytest/test_nanotime.R#L159-L160
https://github.com/eddelbuettel/nanotime/blob/e2486c401cc9ee2f75d36fdf7a36465e212b3998/R/nanotime.R#L132