### PR TITLE
Direct include of used symbols

### DIFF
--- a/src/sort64.c
+++ b/src/sort64.c
@@ -11,6 +11,8 @@
 #define _SORT64_C_SRC
 
 #include <R_ext/Random.h> // unif_rand
+#include <Rinternals.h> // asLogical
+#include "integer64.h" // NA_INTEGER64
 #include "sort64.h"
 
 #define SHELLARRAYSIZE 16


### PR DESCRIPTION
Flagged by `clang`:

http://go/clang-tidy/checks/misc-include-cleaner.md