### PR TITLE
Another round of system requirements

### DIFF
--- a/.dev/revdepcheck.R
+++ b/.dev/revdepcheck.R
@@ -44,6 +44,7 @@ apt_get_packages = c(
   "rustc",
   "libssh-dev",
   "librsvg2-dev",
+  "libjq-dev",
   NULL
 )
 


### PR DESCRIPTION
These are required by some recursive `Suggests`, which in turn unlock passing test suites for some direct downstreams.