### PR TITLE
Progress deprecation of keep.names=

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
    `[<-.integer64`, `abs.integer64`, `all.integer64`, `any.integer64`, `as.character.integer64`, `as.data.frame.integer64`, `as.double.integer64`, `as.integer.integer64`, `as.integer64.character`, `as.integer64.double`, `as.integer64.integer`, `as.integer64.logical`, `c.integer64`, `format.integer64`, `is.na.integer64`, `log.integer64`, `max.integer64`, `min.integer64`, `print.integer64`, `rank.integer64`, `rep.integer64`, `seq.integer64`, `str.integer64`, `sum.integer64`, `unique.integer64`
 
+1. Supplying `keep.names=` to `as.integer64()` now emits a warning, which will become an error in the next release.
+
 ## NOTES
 
 1. The R version dependency has been bumped from 3.5.0 (2018) to 3.6.0 (2019).

--- a/R/integer64.R
+++ b/R/integer64.R
@@ -550,14 +550,16 @@ is.integer64 = function(x) inherits(x, "integer64")
 as.integer64.NULL = function(x, ...) integer64()
 
 #' @rdname as.integer64.character
-#' @param keep.names Logical, default `FALSE`. If `TRUE`, the input's names are retained.
+#' @param keep.names (Deprecated) Logical, default `FALSE`. If `TRUE`, the input's names are retained.
 #' @export
 as.integer64.integer64 = function(x, ..., keep.names=FALSE) {
   ret = unclass(x)
   attributes(ret) = NULL
   oldClass(ret) = "integer64"
-  # for back-compatibility, e.g. {nanotime}
-  if (isTRUE(keep.names)) names(ret) = names(x)
+  if (isTRUE(keep.names)) {
+    warning("keep.names will be removed in a future version. The caller should add names if needed.")
+    names(ret) = names(x)
+  }
   ret
 }
 
@@ -566,7 +568,10 @@ as.integer64.integer64 = function(x, ..., keep.names=FALSE) {
 as.integer64.double = function(x, ..., keep.names=FALSE) {
   ret = .Call(C_as_integer64_double, x, double(length(x)))
   oldClass(ret) = "integer64"
-  if (isTRUE(keep.names)) names(ret) = names(x)
+  if (isTRUE(keep.names)) {
+    warning("keep.names will be removed in a future version. The caller should add names if needed.")
+    names(ret) = names(x)
+  }
   ret
 }
 

--- a/man/as.integer64.character.Rd
+++ b/man/as.integer64.character.Rd
@@ -56,7 +56,7 @@ NA_integer64_
 
 \item{..., units}{further arguments to the \code{\link[=NextMethod]{NextMethod()}}}
 
-\item{keep.names}{Logical, default \code{FALSE}. If \code{TRUE}, the input's names are retained.}
+\item{keep.names}{(Deprecated) Logical, default \code{FALSE}. If \code{TRUE}, the input's names are retained.}
 }
 \value{
 The other methods return atomic vectors of the expected types

--- a/tests/testthat/test-integer64.R
+++ b/tests/testthat/test-integer64.R
@@ -1572,10 +1572,16 @@ test_that("seq.integer64 works with S4 subclasses inheriting from integer64", {
 test_that("back-compatible keep.names=TRUE is supported for limited input classes", {
   x = as.integer64(1L)
   names(x) = "a"
-  expect_named(as.integer64(x, keep.names=TRUE), "a")
+  expect_warning(
+    expect_named(as.integer64(x, keep.names=TRUE), "a"),
+    "keep.names will be removed in a future version"
+  )
 
   y = c(a = 1.0)
-  expect_named(as.integer64(y, keep.names=TRUE), "a")
+  expect_warning(
+    expect_named(as.integer64(y, keep.names=TRUE), "a"),
+    "keep.names will be removed in a future version"
+  )
 })
 
 test_that("bitstring class meshes with R's own (from 4.6.0)", {


### PR DESCRIPTION
I don't expect any new breakage from this, but have started a revdep check run regardless.