### PR TITLE
Fix runif64(replace=FALSE) to guarantee uniqueness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 
 1. Supplying `keep.names=` to `as.integer64()` now emits a warning, which will become an error in the next release.
 
+## BUG FIXES
+
+1. `runif64(replace=FALSE)` no longer generates any duplicates (#337).
+
 ## NOTES
 
 1. The R version dependency has been bumped from 3.5.0 (2018) to 3.6.0 (2019).

--- a/R/hash64.R
+++ b/R/hash64.R
@@ -390,7 +390,7 @@ runif64 <- function(n, min=lim.integer64()[1L], max=lim.integer64()[2L], replace
     if (!is.na(d) && N > d)
       stop("cannot take a sample larger than the population when 'replace = FALSE'")
     if (!is.na(d) && n > d  / (2.0*log(n, 64.0))) {
-      ret <- .Call(C_runif_integer64, as.integer(d), as.integer64(min), as.integer64(max))
+      ret <- .Call(C_seq_integer64, min, as.integer64(1L), double(as.integer(d)))
       oldClass(ret) <- "integer64"
       ret <- sample(ret, n, FALSE)
     } else {

--- a/R/hash64.R
+++ b/R/hash64.R
@@ -389,7 +389,7 @@ runif64 <- function(n, min=lim.integer64()[1L], max=lim.integer64()[2L], replace
     d <- max - min + 1L
     if (!is.na(d) && N > d)
       stop("cannot take a sample larger than the population when 'replace = FALSE'")
-    if (!is.na(d) && n > d  / (2.0*log(n, 64.0))) {
+    if (!is.na(d) && d <= .Machine$integer.max && n > d  / (2.0*log(n, 64.0))) {
       ret <- .Call(C_seq_integer64, min, as.integer64(1L), double(as.integer(d)))
       oldClass(ret) <- "integer64"
       ret <- sample(ret, n, FALSE)

--- a/tests/testthat/test-hash64.R
+++ b/tests/testthat/test-hash64.R
@@ -158,4 +158,9 @@ test_that("runif64 replace=FALSE edge cases", {
   expect_length(r2, 5L)
   expect_length(unique(r2), 5L)
   expect_true(all(r2 >= 1 & r2 <= 1000))
+
+  r3 = runif64(20L, 1, 20, replace=FALSE)
+  expect_length(r3, 20L)
+  expect_length(unique(r3), 20L)
+  expect_true(all(r3 >= 1 & r3 <= 20))
 })


### PR DESCRIPTION
As diagnosed by Gemini:

> The original buggy code tried to optimize by generating `d` random elements with replacement (thus containing duplicates) and then sampling from them without replacement. This is mathematically incorrect because the initial pool already had duplicates, which then leaked into the final sample.                                                                                              
                                                                                                                                                                             
> To keep the optimization (sampling from a pre-generated pool of size `d` when `n` is close to `d`), we must ensure the initial pool contains unique elements of the population. The only correct pool of size `d` between `min` and `max` is the full sequence `min:max`.