### PR TITLE
Fix erroneous offset by na_count and 1-based indexing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 1. Supplying `keep.names=` to `as.integer64()` now emits a warning, which will become an error in the next release.
 
+1. Fix logical errors in the implementation of `order(decreasing=TRUE)` on inputs with missing elements and `ordercache()` set (#340).
+
 ## BUG FIXES
 
 1. `runif64(replace=FALSE)` no longer generates any duplicates (#337).

--- a/src/sortuse64.c
+++ b/src/sortuse64.c
@@ -1346,9 +1346,8 @@ SEXP r_ram_integer64_orderord(
   n = n - na_count;
 
   if (decreasing){
-      data += na_count;
       for(l=n-2,r=n-1,j=0;l>=0;l--)
-        if (data[index[l]]!=data[index[r]]){
+        if (data[index[l] - 1]!=data[index[r] - 1]){
             for (i=l+1;i<=r;i++,j++)
                 ret[j] = index[i];
             r=l;

--- a/tests/testthat/test-sort64.R
+++ b/tests/testthat/test-sort64.R
@@ -506,6 +506,12 @@ test_that("sort.integer64 and order.integer64 with cache", {
   expect_identical(order(x_oc), c(2L, 3L, 1L))
   expect_identical(order(x_oc, decreasing=TRUE), c(1L, 3L, 2L))
   
+  # 3c. order with ordercache only (has order, no sort) - with NAs (Issue #340)
+  x_na = as.integer64(c(3L, NA, 1L, NA, 2L))
+  x_na_oc = bit::clone(x_na)
+  ordercache(x_na_oc)
+  expect_identical(order(x_na_oc, decreasing=TRUE), c(1L, 5L, 3L, 2L, 4L))
+
   # 3b. order with sortordercache (has both order and sort)
   x_soc = bit::clone(x)
   sortordercache(x_soc)


### PR DESCRIPTION
Closes #340.

Written by Gemini -- in a session independent from that for #339, it found the identical solution. Here's the diagnosis:

  1. Incorrect Pointer Shift: The C code was shifting the `data` pointer (which points to the original, unsorted vector) by  `na_count` : `data += na_count;` . Since `index` contains absolute indices into the original unsorted vector, shifting the base pointer caused out-of-bounds memory access and garbage results when `NA`s were present.       
  2. Off-by-one indexing: The C code was using 1-based indices directly from R SEXP `index_` to index the C `data` array (e.g.,  `data[index[l]]` instead of `data[index[l] - 1]`), leading to undefined behavior even when `na_count` was 0.  