### PR TITLE
Remove duplicate R_Busy prototype declaration in src/sortuse64.c

### DIFF
--- a/src/sortuse64.c
+++ b/src/sortuse64.c
@@ -16,8 +16,6 @@
 #include "integer64.h"
 #include "sort64.h"
 
-void R_Busy(int which);
-
 SEXP r_ram_integer64_nacount(
   SEXP x_
 )


### PR DESCRIPTION
R_Busy is already declared in src/sort64.h, which is included by src/sortuse64.c.
