### PR TITLE
Extract bitset manipulation into static inline helpers

### DIFF
--- a/src/integer64.c
+++ b/src/integer64.c
@@ -132,12 +132,13 @@ SEXP as_logical_integer64(SEXP x_, SEXP ret_) {
 SEXP as_character_integer64(SEXP x_, SEXP ret_) {
   long long i, n = LENGTH(ret_);
   long long * x = (long long *) REAL(x_);
-  static char buff[NCHARS_DECS_INTEGER64];
+  // max width 20 before null terminator: -9223372036854775808
+  static char buff[21];
   for (i = 0; i < n; i++) {
     if (is_na64(x[i])) {
       SET_STRING_ELT(ret_, i, NA_STRING);
     } else{
-      snprintf(buff, NCHARS_DECS_INTEGER64, "%lli", x[i]);
+      snprintf(buff, 21, "%lli", x[i]);
       SET_STRING_ELT(ret_, i, mkChar(buff));
     }
   }
@@ -190,7 +191,7 @@ SEXP as_bitstring_integer64(SEXP x_, SEXP ret_) {
   long long * x = (long long *) REAL(x_);
   unsigned long long mask;
   long long v;
-  static char buff[NCHARS_BITS_INTEGER64];
+  static char buff[64+1];
   char * str;
   for (i = 0; i < n; i++) {
     v = x[i];
@@ -222,7 +223,7 @@ SEXP as_integer64_bitstring(SEXP x_, SEXP ret_) {
     str = CHAR(STRING_ELT(x_, i));
     l = strlen(str);
     // # nocov start: only reachable with invalid bitstring input
-    if (l > BITS_INTEGER64) {
+    if (l > 64) {
       ret[i] = NA_INTEGER64;
       naflag = TRUE;
       break;

--- a/src/integer64.h
+++ b/src/integer64.h
@@ -43,9 +43,6 @@ static inline bool is_na64(long long x) {
 #define MAX_INTEGER32 INT_MAX
 #define LEFTBIT_INTEGER64 0x8000000000000000ULL
 #define RIGHTBIT_INTEGER64 0x0000000000000001ULL
-#define NCHARS_BITS_INTEGER64 65
-#define NCHARS_DECS_INTEGER64 22
-#define BITS_INTEGER64 64
 
 #define INTEGER32_OVERFLOW_WARNING "NAs produced by integer overflow"
 #define INTEGER64_OVERFLOW_WARNING "NAs produced by integer64 overflow"

--- a/src/sortuse64.c
+++ b/src/sortuse64.c
@@ -17,7 +17,7 @@
 #include "sort64.h"
 
 static inline ValueT *bitflags_alloc(IndexT n) {
-  IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
+  IndexT nbitflags = n / 64 + (n % 64 ? 1 : 0);
   ValueT *bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
   for (IndexT i = 0; i < nbitflags; i++) {
     bitflags[i] = 0;
@@ -26,11 +26,11 @@ static inline ValueT *bitflags_alloc(IndexT n) {
 }
 
 static inline void bitflags_set(ValueT *bitflags, IndexT k) {
-  bitflags[k / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << (k % BITS_INTEGER64));
+  bitflags[k / 64] |= (RIGHTBIT_INTEGER64 << (k % 64));
 }
 
 static inline bool bitflags_test(const ValueT *bitflags, IndexT k) {
-  return (bitflags[k / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (k % BITS_INTEGER64))) != 0;
+  return (bitflags[k / 64] & (RIGHTBIT_INTEGER64 << (k % 64))) != 0;
 }
 
 SEXP r_ram_integer64_nacount(

--- a/src/sortuse64.c
+++ b/src/sortuse64.c
@@ -16,6 +16,23 @@
 #include "integer64.h"
 #include "sort64.h"
 
+static inline ValueT *bitflags_alloc(IndexT n) {
+  IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
+  ValueT *bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
+  for (IndexT i = 0; i < nbitflags; i++) {
+    bitflags[i] = 0;
+  }
+  return bitflags;
+}
+
+static inline void bitflags_set(ValueT *bitflags, IndexT k) {
+  bitflags[k / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << (k % BITS_INTEGER64));
+}
+
+static inline bool bitflags_test(const ValueT *bitflags, IndexT k) {
+  return (bitflags[k / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (k % BITS_INTEGER64))) != 0;
+}
+
 SEXP r_ram_integer64_nacount(
   SEXP x_
 )
@@ -522,21 +539,17 @@ SEXP r_ram_integer64_sortorderuni_asc(
   ValueT lastval;
   if (n) {
     R_Busy(1);
-    IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-    ValueT *bitflags;
-    bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-    for (i = 0; i < nbitflags; i++)
-      bitflags[i] = 0;
+    ValueT *bitflags = bitflags_alloc(n);
     lastval = sorted[0];
-    bitflags[(index[0] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[0] - 1) % BITS_INTEGER64));
+    bitflags_set(bitflags, index[0] - 1);
     for (i = 1; i < n; i++)
       if (sorted[i] != lastval) {
-        bitflags[(index[i] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[i] - 1) % BITS_INTEGER64));
+        bitflags_set(bitflags, index[i] - 1);
         lastval = sorted[i];
       }
     pos = 0;
     for (i = 0; i < n; i++)
-      if ((bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64))))
+      if (bitflags_test(bitflags, i))
         ret[pos++] = table[i];
     R_Busy(0);
   }
@@ -559,23 +572,19 @@ SEXP r_ram_integer64_orderuni_asc(
   if (n) {
     R_Busy(1);
     if (asLogical(keep_order_)) {
-      IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-      ValueT *bitflags;
-      bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-      for (i = 0; i < nbitflags; i++)
-        bitflags[i] = 0;
+      ValueT *bitflags = bitflags_alloc(n);
       lastval = table[index[0] - 1];
-      bitflags[(index[0] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[0] - 1) % BITS_INTEGER64));
+      bitflags_set(bitflags, index[0] - 1);
       for (i = 1; i < n; i++) {
         pos = index[i] - 1;
         if (table[pos] != lastval) {
-          bitflags[pos / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << (pos % BITS_INTEGER64));
+          bitflags_set(bitflags, pos);
           lastval = table[pos];
         }
       }
       pos = 0;
       for (i = 0; i < n; i++)
-        if ((bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64))))
+        if (bitflags_test(bitflags, i))
           ret[pos++] = table[i];
     } else {
       lastval = table[index[0] - 1];
@@ -611,21 +620,17 @@ SEXP r_ram_integer64_sortorderupo_asc(
   if (n) {
     R_Busy(1);
     if (asLogical(keep_order_)) {
-      IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-      ValueT *bitflags;
-      bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-      for (i = 0; i < nbitflags; i++)
-        bitflags[i] = 0;
+      ValueT *bitflags = bitflags_alloc(n);
       lastval = sorted[0];
-      bitflags[(index[0] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[0] - 1) % BITS_INTEGER64));
+      bitflags_set(bitflags, index[0] - 1);
       for (i = 1; i < n; i++)
         if (sorted[i] != lastval) {
-          bitflags[(index[i] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[i] - 1) % BITS_INTEGER64));
+          bitflags_set(bitflags, index[i] - 1);
           lastval = sorted[i];
         }
       pos = 0;
       for (i = 0; i < n; i++)
-        if ((bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64))))
+        if (bitflags_test(bitflags, i))
           ret[pos++] = i + 1;
     } else {
       ret[0] = index[0];
@@ -657,23 +662,19 @@ SEXP r_ram_integer64_orderupo_asc(
   if (n) {
     R_Busy(1);
     if (asLogical(keep_order_)) {
-      IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-      ValueT *bitflags;
-      bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-      for (i = 0; i < nbitflags; i++)
-        bitflags[i] = 0;
+      ValueT *bitflags = bitflags_alloc(n);
       lastval = table[index[0] - 1];
-      bitflags[(index[0] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[0] - 1) % BITS_INTEGER64));
+      bitflags_set(bitflags, index[0] - 1);
       for (i = 1; i < n; i++) {
         pos = index[i] - 1;
         if (table[pos] != lastval) {
-          bitflags[pos / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << (pos % BITS_INTEGER64));
+          bitflags_set(bitflags, pos);
           lastval = table[pos];
         }
       }
       pos = 0;
       for (i = 0; i < n; i++)
-        if ((bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64))))
+        if (bitflags_test(bitflags, i))
           ret[pos++] = i + 1;
     } else {
       ret[0] = index[0];
@@ -1034,22 +1035,18 @@ SEXP r_ram_integer64_orderdup_asc(
           break;
         }
         case 2: {
-          IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-          ValueT *bitflags;
-          bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-          for (i = 0; i < nbitflags; i++)
-            bitflags[i] = 0;
+          ValueT *bitflags = bitflags_alloc(n);
           lastval = table[index[0] - 1];
-          bitflags[(index[0] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[0] - 1) % BITS_INTEGER64));
+          bitflags_set(bitflags, index[0] - 1);
           for (i = 1; i < n; i++) {
             pos = index[i] - 1;
             if (table[pos] != lastval) {
-              bitflags[pos / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << (pos % BITS_INTEGER64));
+              bitflags_set(bitflags, pos);
               lastval = table[pos];
             }
           }
           for (i = 0; i < n; i++)
-            ret[i] = !(bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64)));
+            ret[i] = !bitflags_test(bitflags, i);
           break;
         }
         default:
@@ -1090,19 +1087,15 @@ SEXP r_ram_integer64_sortorderdup_asc(
           break;
         }
         case 2: {
-          IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-          ValueT *bitflags;
-          bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-          for (i = 0; i < nbitflags; i++)
-            bitflags[i] = 0;
-          bitflags[(index[0] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[0] - 1) % BITS_INTEGER64));
+          ValueT *bitflags = bitflags_alloc(n);
+          bitflags_set(bitflags, index[0] - 1);
           for (i = 1; i < n; i++) {
             if (sorted[i] != sorted[i - 1]) {
-              bitflags[(index[i] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[i] - 1) % BITS_INTEGER64));
+              bitflags_set(bitflags, index[i] - 1);
             }
           }
           for (i = 0; i < n; i++)
-            ret[i] = !(bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64)));
+            ret[i] = !bitflags_test(bitflags, i);
           break;
         }
         default:
@@ -1130,28 +1123,24 @@ SEXP r_ram_integer64_sortordertie_asc(
 
   if (n) {
     R_Busy(1);
-    IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-    ValueT *bitflags;
-    bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-    for (i = 0; i < nbitflags; i++)
-      bitflags[i] = 0;
+    ValueT *bitflags = bitflags_alloc(n);
     j = 0;
     for (i = 1; i < n; i++)
       if (sorted[i] != sorted[j]) {
         if (i > j + 1) {
           for (; j < i; j++)
-            bitflags[(index[j] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[j] - 1) % BITS_INTEGER64));
+            bitflags_set(bitflags, index[j] - 1);
         } else {
           j = i;
         }
       }
     if (i > j + 1) {
       for (; j < i; j++)
-        bitflags[(index[j] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[j] - 1) % BITS_INTEGER64));
+        bitflags_set(bitflags, index[j] - 1);
     }
     j = 0;
     for (i = 0; i < n; i++)
-      if ((bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64))))
+      if (bitflags_test(bitflags, i))
         ret[j++] = i + 1;
     R_Busy(0);
   }
@@ -1171,18 +1160,14 @@ SEXP r_ram_integer64_ordertie_asc(
   IndexT *ret = INTEGER(ret_);
   if (n) {
     R_Busy(1);
-    IndexT nbitflags = n / BITS_INTEGER64 + (n % BITS_INTEGER64 ? 1 : 0);
-    ValueT *bitflags;
-    bitflags = (ValueT *) R_alloc(nbitflags, sizeof(ValueT));
-    for (i = 0; i < nbitflags; i++)
-      bitflags[i] = 0;
+    ValueT *bitflags = bitflags_alloc(n);
     j = 0;
     pos = index[0] - 1;
     for (i = 1; i < n; i++)
       if (table[index[i] - 1] != table[pos]) {
         if (i > j + 1) {
           for (; j < i; j++)
-            bitflags[(index[j] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[j] - 1) % BITS_INTEGER64));
+            bitflags_set(bitflags, index[j] - 1);
         } else {
           j = i;
         }
@@ -1190,11 +1175,11 @@ SEXP r_ram_integer64_ordertie_asc(
       }
     if (i > j + 1) {
       for (; j < i; j++)
-        bitflags[(index[j] - 1) / BITS_INTEGER64] |= (RIGHTBIT_INTEGER64 << ((index[j] - 1) % BITS_INTEGER64));
+        bitflags_set(bitflags, index[j] - 1);
     }
     j = 0;
     for (i = 0; i < n; i++)
-      if ((bitflags[i / BITS_INTEGER64] & (RIGHTBIT_INTEGER64 << (i % BITS_INTEGER64))))
+      if (bitflags_test(bitflags, i))
         ret[j++] = i + 1;
 
     R_Busy(0);


### PR DESCRIPTION
Deduplicate the bitflags allocation, setting, and testing logic in src/sortuse64.c by introducing static inline helpers: bitflags_alloc, bitflags_set, and bitflags_test.
