### PR TITLE
Create modular header structure

### DIFF
--- a/src/hash64.c
+++ b/src/hash64.c
@@ -7,9 +7,11 @@
 # Provided 'as is', use at your own risk
 #*/
 
-#include <Rinternals.h>
 #include <R.h>
+#include <Rinternals.h>
 #include <R_ext/Boolean.h> // TRUE,FALSE
+
+#include "hash64.h"
 
 // This multiplicator was used in Simon Urbanek's package fastmatch for 32-bit integers
 //   (314159265358979323ULL * ((unsigned long long)(X)) >> (SHIFT))
@@ -380,48 +382,6 @@ SEXP hashmapupo_integer64(SEXP x_, SEXP bits_, SEXP hashpos_, SEXP nunique_) {
   }
   INTEGER(nunique_)[0] = nu;
   REPROTECT(ret_ = lengthgets(ret_, nu), idx);
-  UNPROTECT(1);
-  return ret_;
-}
-
-
-
-SEXP hashtab_integer641(SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP nunique_) {
-  int i, nx = LENGTH(hashdat_);
-  int h, nh = LENGTH(hashpos_);
-  int u;
-  long long * hashdat = (long long *) REAL(hashdat_);
-  unsigned int * hashpos = (unsigned int *) INTEGER(hashpos_);
-  //int * pos = INTEGER(pos_);
-  SEXP ret_;
-  PROTECT_INDEX idx;
-  PROTECT_WITH_INDEX(ret_ = allocVector(INTSXP, nh), &idx);
-  int * ret = INTEGER(ret_);
-  int bits = asInteger(bits_);
-  int shift = 64 - bits;
-  long long v;
-  for(i=0; i<nh; i++)
-    ret[i]=0;
-  for(i=0; i<nx; i++) {
-    v = hashdat[i];
-    h = hash64(v, shift);
-    while(hashpos[h]) {  // this is mostly while(hashpos[h]) but we want to catch failure for the nomatch assignment
-      if (hashdat[hashpos[h] - 1] == v) {
-        ret[h]++;
-        break;
-      }
-      h++;
-      if (h == nh)
-        h = 0;
-    }
-  }
-  for (u=0,h=0;h<nh;h++) {
-    if (hashpos[h]) {
-      //pos[u]=hashpos[h];
-      ret[u++]=ret[h];
-    }
-  }
-  REPROTECT(ret_ = lengthgets(ret_, u), idx);
   UNPROTECT(1);
   return ret_;
 }

--- a/src/hash64.h
+++ b/src/hash64.h
@@ -1,0 +1,20 @@
+#ifndef BIT64_SRC_HASH64_H_
+#define BIT64_SRC_HASH64_H_
+
+#include <Rinternals.h>
+
+SEXP hashdup_integer64(SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP nunique_, SEXP ret_);
+SEXP hashfin_integer64(SEXP x_, SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP ret_);
+SEXP hashfun_integer64(SEXP x_, SEXP bits_, SEXP ret_);
+SEXP hashmap_integer64(SEXP x_, SEXP bits_, SEXP hashpos_, SEXP nunique_);
+SEXP hashmaptab_integer64(SEXP x_, SEXP bits_, SEXP hashpos_, SEXP nunique_);
+SEXP hashmapuni_integer64(SEXP x_, SEXP bits_, SEXP hashpos_, SEXP nunique_);
+SEXP hashmapupo_integer64(SEXP x_, SEXP bits_, SEXP hashpos_, SEXP nunique_);
+SEXP hashpos_integer64(SEXP x_, SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP nomatch_, SEXP ret_);
+SEXP hashrev_integer64(SEXP x_, SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP nunique_, SEXP nomatch_, SEXP ret_);
+SEXP hashrin_integer64(SEXP x_, SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP nunique_, SEXP ret_);
+SEXP hashtab_integer64(SEXP x_, SEXP bits_, SEXP hashpos_, SEXP nunique_);
+SEXP hashuni_integer64(SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP keep_order_, SEXP ret_);
+SEXP hashupo_integer64(SEXP hashdat_, SEXP bits_, SEXP hashpos_, SEXP keep_order_, SEXP ret_);
+
+#endif  // BIT64_SRC_HASH64_H_

--- a/src/init.c
+++ b/src/init.c
@@ -1,118 +1,14 @@
+#include <stdlib.h> // for NULL
+
 #include <R.h>
 #include <Rinternals.h>
-#include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-/* .Call calls */
-SEXP as_list_integer64(SEXP);
-SEXP abs_integer64(SEXP, SEXP);
-SEXP all_integer64(SEXP, SEXP, SEXP);
-SEXP any_integer64(SEXP, SEXP, SEXP);
-SEXP as_bitstring_integer64(SEXP, SEXP);
-SEXP as_character_integer64(SEXP, SEXP);
-SEXP as_double_integer64(SEXP, SEXP);
-SEXP as_integer64_bitstring(SEXP, SEXP);
-SEXP as_integer64_character(SEXP, SEXP);
-SEXP as_integer64_double(SEXP, SEXP);
-SEXP as_integer64_integer(SEXP, SEXP);
-SEXP as_integer_integer64(SEXP, SEXP);
-SEXP as_logical_integer64(SEXP, SEXP);
-SEXP cummax_integer64(SEXP, SEXP);
-SEXP cummin_integer64(SEXP, SEXP);
-SEXP cumprod_integer64(SEXP, SEXP);
-SEXP cumsum_integer64(SEXP, SEXP);
-SEXP diff_integer64(SEXP, SEXP, SEXP, SEXP);
-SEXP divide_integer64_double(SEXP, SEXP, SEXP);
-SEXP divide_double_integer64(SEXP, SEXP, SEXP); /* Ofek Shilon */
-SEXP divide_integer64_integer64(SEXP, SEXP, SEXP);
-SEXP EQ_integer64(SEXP, SEXP, SEXP);
-SEXP GE_integer64(SEXP, SEXP, SEXP);
-SEXP GT_integer64(SEXP, SEXP, SEXP);
-SEXP hashdup_integer64(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP hashfin_integer64(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP hashfun_integer64(SEXP, SEXP, SEXP);
-SEXP hashmap_integer64(SEXP, SEXP, SEXP, SEXP);
-SEXP hashmaptab_integer64(SEXP, SEXP, SEXP, SEXP);
-SEXP hashmapuni_integer64(SEXP, SEXP, SEXP, SEXP);
-SEXP hashmapupo_integer64(SEXP, SEXP, SEXP, SEXP);
-SEXP hashpos_integer64(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP hashrev_integer64(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP hashrin_integer64(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP hashtab_integer64(SEXP, SEXP, SEXP, SEXP);
-SEXP hashuni_integer64(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP hashupo_integer64(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP intdiv_integer64(SEXP, SEXP, SEXP);
-SEXP isna_integer64(SEXP, SEXP);
-SEXP LE_integer64(SEXP, SEXP, SEXP);
-SEXP lim_integer64(SEXP);
-SEXP log10_integer64(SEXP, SEXP);
-SEXP log2_integer64(SEXP, SEXP);
-SEXP logbase_integer64(SEXP, SEXP, SEXP);
-SEXP log_integer64(SEXP, SEXP);
-SEXP logvect_integer64(SEXP, SEXP, SEXP);
-SEXP LT_integer64(SEXP, SEXP, SEXP);
-SEXP matmult_double_integer64(SEXP, SEXP, SEXP);
-SEXP matmult_integer64_double(SEXP, SEXP, SEXP);
-SEXP matmult_integer64_integer64(SEXP, SEXP, SEXP);
-SEXP max_integer64(SEXP, SEXP, SEXP);
-SEXP mean_integer64(SEXP, SEXP, SEXP);
-SEXP min_integer64(SEXP, SEXP, SEXP);
-SEXP minus_integer64(SEXP, SEXP, SEXP);
-SEXP mod_integer64(SEXP, SEXP, SEXP);
-SEXP NE_integer64(SEXP, SEXP, SEXP);
-SEXP plus_integer64(SEXP, SEXP, SEXP);
-SEXP power_integer64_double(SEXP, SEXP, SEXP);
-SEXP power_integer64_integer64(SEXP, SEXP, SEXP);
-SEXP prod_integer64(SEXP, SEXP, SEXP);
-SEXP range_integer64(SEXP, SEXP, SEXP);
-SEXP runif_integer64(SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_issorted_asc(SEXP);
-SEXP r_ram_integer64_mergeorder(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_mergesort(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_mergesortorder(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_all_na(SEXP);
-SEXP r_ram_integer64_any_na(SEXP);
-SEXP r_ram_integer64_nacount(SEXP);
-SEXP r_ram_integer64_orderdup_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_orderfin_asc(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_orderkey_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_ordernut(SEXP, SEXP);
-SEXP r_ram_integer64_orderord(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_orderpos_asc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_orderrnk_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_ordertab_asc(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_ordertie_asc(SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_orderuni_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_orderupo_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_quickorder(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_quicksort(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_quicksortorder(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_radixorder(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_radixsort(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_radixsortorder(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_shellorder(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_shellsort(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_shellsortorder(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortfin_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortnut(SEXP);
-SEXP r_ram_integer64_sortorderdup_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortorderkey_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortorderord(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortorderpos_asc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortorderrnk_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortordertab_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortordertie_asc(SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortorderuni_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortorderupo_asc(SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sortsrt(SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP r_ram_integer64_sorttab_asc(SEXP, SEXP);
-SEXP r_ram_integer64_sortuni_asc(SEXP, SEXP);
-SEXP seq_integer64(SEXP, SEXP, SEXP);
-SEXP sign_integer64(SEXP, SEXP);
-SEXP sqrt_integer64(SEXP, SEXP);
-SEXP sum_integer64(SEXP, SEXP, SEXP);
-SEXP times_integer64_double(SEXP, SEXP, SEXP);
-SEXP times_integer64_integer64(SEXP, SEXP, SEXP);
+#include "hash64.h"
+#include "integer64.h"
+#include "sortuse64.h"
+
+
 
 static const R_CallMethodDef CallEntries[] = {
     {"as_list_integer64",                (DL_FUNC) &as_list_integer64,                1},

--- a/src/integer64.h
+++ b/src/integer64.h
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 
 #include <R.h>
+#include <Rinternals.h>
 #include <R_ext/Arith.h>
 #include <R_ext/Boolean.h>
 
@@ -458,5 +459,67 @@ static inline int ge64(long long e1, long long e2) {
   }
   return e1 >= e2;
 }
+
+/*****************************************************************************/
+/**                                                                         **/
+/**                        EXPORTED SEXP FUNCTIONS                          **/
+/**                                                                         **/
+/*****************************************************************************/
+
+SEXP as_integer64_double(SEXP x_, SEXP ret_);
+SEXP as_integer64_integer(SEXP x_, SEXP ret_);
+SEXP as_double_integer64(SEXP x_, SEXP ret_);
+SEXP as_integer_integer64(SEXP x_, SEXP ret_);
+SEXP as_logical_integer64(SEXP x_, SEXP ret_);
+SEXP as_character_integer64(SEXP x_, SEXP ret_);
+SEXP as_integer64_character(SEXP x_, SEXP ret_);
+SEXP as_bitstring_integer64(SEXP x_, SEXP ret_);
+SEXP as_integer64_bitstring(SEXP x_, SEXP ret_);
+SEXP plus_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP minus_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP diff_integer64(SEXP x_, SEXP lag_, SEXP n_, SEXP ret_);
+SEXP intdiv_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP mod_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP times_integer64_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP times_integer64_double(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP power_integer64_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP power_integer64_double(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP divide_integer64_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP divide_integer64_double(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP divide_double_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP sign_integer64(SEXP e1_, SEXP ret_);
+SEXP abs_integer64(SEXP e1_, SEXP ret_);
+SEXP sqrt_integer64(SEXP e1_, SEXP ret_);
+SEXP log_integer64(SEXP e1_, SEXP ret_);
+SEXP logvect_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP logbase_integer64(SEXP e1_, SEXP base_, SEXP ret_);
+SEXP log10_integer64(SEXP e1_, SEXP ret_);
+SEXP log2_integer64(SEXP e1_, SEXP ret_);
+SEXP any_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP all_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP sum_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP mean_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP prod_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP min_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP max_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP range_integer64(SEXP e1_, SEXP na_rm_, SEXP ret_);
+SEXP lim_integer64(SEXP ret_);
+SEXP cummin_integer64(SEXP e1_, SEXP ret_);
+SEXP cummax_integer64(SEXP e1_, SEXP ret_);
+SEXP cumsum_integer64(SEXP e1_, SEXP ret_);
+SEXP cumprod_integer64(SEXP e1_, SEXP ret_);
+SEXP seq_integer64(SEXP from_, SEXP by_, SEXP ret_);
+SEXP isna_integer64(SEXP e1_, SEXP ret_);
+SEXP EQ_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP NE_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP LT_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP LE_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP GT_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP GE_integer64(SEXP e1_, SEXP e2_, SEXP ret_);
+SEXP runif_integer64(SEXP n_, SEXP min_, SEXP max_);
+SEXP as_list_integer64(SEXP x_);
+SEXP matmult_integer64_integer64(SEXP x_, SEXP y_, SEXP ret_);
+SEXP matmult_double_integer64(SEXP x_, SEXP y_, SEXP ret_);
+SEXP matmult_integer64_double(SEXP x_, SEXP y_, SEXP ret_);
 
 #endif  // BIT64_SRC_INTEGER64_H_

--- a/src/sortuse64.c
+++ b/src/sortuse64.c
@@ -17,6 +17,7 @@
 #include "bsearch.h"
 #include "integer64.h"
 #include "sort64.h"
+#include "sortuse64.h"
 
 static inline ValueT *bitflags_alloc(IndexT n) {
   IndexT nbitflags = n / 64 + (n % 64 ? 1 : 0);

--- a/src/sortuse64.h
+++ b/src/sortuse64.h
@@ -1,0 +1,48 @@
+#ifndef BIT64_SRC_SORTUSE64_H_
+#define BIT64_SRC_SORTUSE64_H_
+
+#include <Rinternals.h>
+
+SEXP r_ram_integer64_all_na(SEXP x_);
+SEXP r_ram_integer64_any_na(SEXP x_);
+SEXP r_ram_integer64_issorted_asc(SEXP x_);
+SEXP r_ram_integer64_mergeorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_);
+SEXP r_ram_integer64_mergesort(SEXP x_, SEXP has_na_, SEXP na_last_, SEXP decreasing_);
+SEXP r_ram_integer64_mergesortorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_);
+SEXP r_ram_integer64_nacount(SEXP x_);
+SEXP r_ram_integer64_orderdup_asc(SEXP table_, SEXP order_, SEXP method_, SEXP ret_);
+SEXP r_ram_integer64_orderfin_asc(SEXP x_, SEXP table_, SEXP order_, SEXP method_, SEXP ret_);
+SEXP r_ram_integer64_orderkey_asc(SEXP table_, SEXP order_, SEXP na_skip_num_, SEXP ret_);
+SEXP r_ram_integer64_ordernut(SEXP table_, SEXP order_);
+SEXP r_ram_integer64_orderord(SEXP x_, SEXP index_, SEXP na_count_, SEXP na_last_, SEXP decreasing_, SEXP ret_);
+SEXP r_ram_integer64_orderpos_asc(SEXP x_, SEXP table_, SEXP order_, SEXP nomatch_, SEXP method_, SEXP ret_);
+SEXP r_ram_integer64_orderrnk_asc(SEXP table_, SEXP order_, SEXP nacount_, SEXP ret_);
+SEXP r_ram_integer64_ordertab_asc(SEXP table_, SEXP order_, SEXP denormalize_, SEXP keep_order_, SEXP ret_);
+SEXP r_ram_integer64_ordertie_asc(SEXP table_, SEXP order_, SEXP ret_);
+SEXP r_ram_integer64_orderuni_asc(SEXP table_, SEXP order_, SEXP keep_order_, SEXP ret_);
+SEXP r_ram_integer64_orderupo_asc(SEXP table_, SEXP order_, SEXP keep_order_, SEXP ret_);
+SEXP r_ram_integer64_quickorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_, SEXP restlevel_);
+SEXP r_ram_integer64_quicksort(SEXP x_, SEXP has_na_, SEXP na_last_, SEXP decreasing_, SEXP restlevel_);
+SEXP r_ram_integer64_quicksortorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_, SEXP restlevel_);
+SEXP r_ram_integer64_radixorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_, SEXP radixbits_);
+SEXP r_ram_integer64_radixsort(SEXP x_, SEXP has_na_, SEXP na_last_, SEXP decreasing_, SEXP radixbits_);
+SEXP r_ram_integer64_radixsortorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_, SEXP radixbits_);
+SEXP r_ram_integer64_shellorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_);
+SEXP r_ram_integer64_shellsort(SEXP x_, SEXP has_na_, SEXP na_last_, SEXP decreasing_);
+SEXP r_ram_integer64_shellsortorder(SEXP x_, SEXP index_, SEXP has_na_, SEXP na_last_, SEXP decreasing_);
+SEXP r_ram_integer64_sortfin_asc(SEXP x_, SEXP sorted_, SEXP method_, SEXP ret_);
+SEXP r_ram_integer64_sortnut(SEXP sorted_);
+SEXP r_ram_integer64_sortorderdup_asc(SEXP sorted_, SEXP order_, SEXP method_, SEXP ret_);
+SEXP r_ram_integer64_sortorderkey_asc(SEXP sorted_, SEXP order_, SEXP na_skip_num_, SEXP ret_);
+SEXP r_ram_integer64_sortorderord(SEXP x_, SEXP index_, SEXP na_count_, SEXP na_last_, SEXP decreasing_, SEXP ret_);
+SEXP r_ram_integer64_sortorderpos_asc(SEXP x_, SEXP sorted_, SEXP order_, SEXP nomatch_, SEXP method_, SEXP ret_);
+SEXP r_ram_integer64_sortorderrnk_asc(SEXP sorted_, SEXP order_, SEXP nacount_, SEXP ret_);
+SEXP r_ram_integer64_sortordertab_asc(SEXP sorted_, SEXP order_, SEXP denormalize_, SEXP ret_);
+SEXP r_ram_integer64_sortordertie_asc(SEXP sorted_, SEXP order_, SEXP ret_);
+SEXP r_ram_integer64_sortorderuni_asc(SEXP table_, SEXP sorted_, SEXP order_, SEXP ret_);
+SEXP r_ram_integer64_sortorderupo_asc(SEXP sorted_, SEXP order_, SEXP keep_order_, SEXP ret_);
+SEXP r_ram_integer64_sortsrt(SEXP x_, SEXP na_count_, SEXP na_last_, SEXP decreasing_, SEXP ret_);
+SEXP r_ram_integer64_sorttab_asc(SEXP sorted_, SEXP ret_);
+SEXP r_ram_integer64_sortuni_asc(SEXP sorted_, SEXP ret_);
+
+#endif  // BIT64_SRC_SORTUSE64_H_


### PR DESCRIPTION
 - Add src/hash64.h and declare SEXP hash entry points
 - Add src/sortuse64.h and declare SEXP sort entry points
 - Include modular headers in src/init.c to replace manual routine declarations
 - Declare SEXP entry points in src/integer64.h
 - Replace the ~60 manual forward declarations in src/init.c with includes of hash64.h, integer64.h, and sortuse64.h, ensuring full compile-time type safety and signature verification for R's dynamic symbol registration table.